### PR TITLE
fix: parse Maven license metadata from JARs

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -43,10 +43,15 @@ class Job < ApplicationRecord
     path = working_directory(dir)
 
     case mime_type(path)
-    when "application/zip", "application/java-archive"
+    when "application/zip"
       destination = File.join([dir, 'zip'])
       `mkdir #{destination} && bsdtar --strip-components=1 -xvf #{path} -C #{destination} > /dev/null 2>&1 `
       results = licensee_as_json(destination)
+    when "application/java-archive"
+      destination = File.join([dir, 'jar'])
+      `mkdir #{destination} && bsdtar -xvf #{path} -C #{destination} > /dev/null 2>&1 `
+      results = licensee_as_json(destination)
+      results = merge_package_metadata_licenses(results, destination)
     when "application/gzip"
       destination = File.join([dir, 'tar'])
       `mkdir #{destination} && tar xzf #{path} -C #{destination} --strip-components 1`
@@ -61,16 +66,7 @@ class Job < ApplicationRecord
   def licensee_as_json(path)
     project = Licensee::Projects::FSProject.new path, detect_readme: true
     licenses = project.licenses.map do |license|
-      {
-        key: license.key,
-        name: license.name,
-        source: license.name,
-        description: license.name,
-        content: license.content,
-        permissions: license.name,
-        conditions: license.name,
-        limitations: license.name
-      }
+      license_as_json(license)
     end
     matched_files = project.matched_files.map do |file|
       {
@@ -82,6 +78,46 @@ class Job < ApplicationRecord
     {
       licenses: licenses,
       matched_files: matched_files
+    }
+  end
+
+  def merge_package_metadata_licenses(results, path)
+    package_licenses = maven_package_licenses(path)
+    return results if package_licenses.empty?
+
+    existing_keys = results[:licenses].map { |license| license[:key] }
+    results[:licenses] += package_licenses.reject { |license| existing_keys.include?(license[:key]) }
+    results
+  end
+
+  def maven_package_licenses(path)
+    Dir.glob(File.join(path, 'META-INF', 'maven', '**', 'pom.xml')).flat_map do |pom_path|
+      document = Nokogiri::XML(File.read(pom_path))
+      document.remove_namespaces!
+      document.xpath('//licenses/license/name').map(&:text).flat_map do |license_name|
+        licenses_from_expression(license_name)
+      end
+    end
+  end
+
+  def licenses_from_expression(expression)
+    expression.scan(/[A-Za-z0-9.-]+/).filter_map do |token|
+      token = token.sub(/-or-later\z/i, '')
+      license = Licensee.licenses.find { |candidate| candidate.spdx_id.casecmp?(token) || candidate.key.casecmp?(token.downcase) }
+      license_as_json(license) if license
+    end
+  end
+
+  def license_as_json(license)
+    {
+      key: license.key,
+      name: license.name,
+      source: license.name,
+      description: license.name,
+      content: license.content,
+      permissions: license.name,
+      conditions: license.name,
+      limitations: license.name
     }
   end
 

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -47,10 +47,10 @@ class JobTest < ActiveSupport::TestCase
     Dir.mktmpdir do |dir|
       FileUtils.cp(File.join(file_fixture_path, 'clj-data-adapter-0.2.1.jar'), dir)
       results = @job.parse_licenses(dir)
-      assert_equal results[:licenses].length, 0
+      assert_equal ["epl-2.0", "gpl-2.0"], results[:licenses].map { |license| license[:key] }
+      assert_equal "Eclipse Public License 2.0", results[:licenses].first[:name]
+      assert_equal "GNU General Public License v2.0", results[:licenses].second[:name]
       assert_equal results[:matched_files].length, 0
-      assert_empty results[:licenses]
-      assert_empty results[:matched_files]
     end
   end
 end


### PR DESCRIPTION
## Summary
- parse Maven `pom.xml` license metadata when handling JAR uploads
- preserve the full JAR layout instead of stripping the first path component
- reuse the existing Licensee JSON shape for licenses discovered from package metadata

## Validation
- `PATH=/opt/homebrew/opt/ruby/bin:$PATH bundle exec rails db:create db:schema:load`
- `PATH=/opt/homebrew/opt/ruby/bin:$PATH bundle exec rails test test/models/job_test.rb` (7 runs, 14 assertions, 0 failures)

Fixes #153