### PR TITLE
feat: add Go v2 scan API backed by git-pkgs/licenses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,28 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
+  go:
+    name: Go v2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Check formatting
+        run: test -z "$(gofmt -l cmd internal)"
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...
+      - name: Build
+        run: go build ./cmd/server
+
   verify:
-    name: Build
+    name: Rails v1
     runs-on: ubuntu-latest
 
     services:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,6 +12,7 @@ The project uses ruby on rails which have a number of system dependencies you'll
 - [postgresql 14](https://www.postgresql.org/download/)
 - [redis 6+](https://redis.io/download/)
 - [node.js 16+](https://nodejs.org/en/download/)
+- [Go 1.25.6+](https://go.dev/doc/install) for the v2 preview service
 
 Once you've got all of those installed, from the root directory of the project run the following commands:
 
@@ -44,6 +45,59 @@ The applications tests can be found in [test](test) and use the testing framewor
 You can run all the tests with:
 
 `rails test`
+
+Run the Go v2 checks with:
+
+```bash
+gofmt -w cmd internal
+go vet ./...
+go test ./...
+go build ./cmd/server
+```
+
+## Go v2 preview
+
+The Go service is additive during the staged migration: it does not replace or
+remove the Rails v1 application. Start it locally on port 5000:
+
+```bash
+go run ./cmd/server
+```
+
+Then request a scan from a public HTTP or HTTPS archive URL:
+
+```bash
+curl --get http://localhost:5000/api/v2/licenses \
+  --data-urlencode 'url=https://example.test/package.tar.gz'
+```
+
+The service rejects private and loopback destinations in production, validates
+redirects, and bounds download size, archive expansion, entries, path depth,
+per-file scanning, attribution contents, request duration, and concurrent
+scans. Configuration currently supported by the server process:
+
+- `PORT` (default `5000`)
+- `SCAN_TIMEOUT` (default `120s`)
+- `MAX_CONCURRENT_SCANS` (default `4`)
+- `OPENAPI_PATH` (default `openapi/api/v2/openapi.yaml`)
+- `MAX_DOWNLOAD_BYTES` (default `104857600`)
+- `MAX_ARCHIVE_ENTRIES` (default `10000`)
+- `MAX_ARCHIVE_DEPTH` (default `64`)
+- `MAX_ENTRY_BYTES` (default `33554432`)
+- `MAX_EXPANDED_BYTES` (default `536870912`)
+- `MAX_SCAN_FILES` (default `10000`)
+- `MAX_SCAN_DEPTH` (default `32`)
+- `MAX_SCAN_FILE_BYTES` (default `1048576`)
+- `SCAN_WORKERS` (default up to `16`, bounded by available CPUs)
+- `MAX_ATTRIBUTION_FILES` (default `64`)
+- `MAX_ATTRIBUTION_BYTES` (default `4194304`)
+
+Build the independent preview image without changing the Rails image:
+
+```bash
+docker build -f Dockerfile.v2 -t licenses-v2 .
+docker run --rm -p 5000:5000 licenses-v2
+```
 
 ## Background tasks 
 

--- a/Dockerfile.v2
+++ b/Dockerfile.v2
@@ -1,0 +1,26 @@
+FROM golang:1.25.6-alpine AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd/ ./cmd/
+COPY internal/ ./internal/
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/licenses-v2 ./cmd/server
+
+FROM alpine:3.24
+
+RUN apk add --no-cache ca-certificates \
+ && addgroup -S licenses \
+ && adduser -S -G licenses licenses
+
+WORKDIR /app
+COPY --from=builder /out/licenses-v2 /app/licenses-v2
+COPY openapi/api/v2/openapi.yaml /app/openapi/api/v2/openapi.yaml
+
+USER licenses
+EXPOSE 5000
+ENV PORT=5000
+ENV OPENAPI_PATH=/app/openapi/api/v2/openapi.yaml
+
+CMD ["/app/licenses-v2"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ This project is part of [Ecosyste.ms](https://ecosyste.ms): Tools and open datas
 
 Documentation for the REST API is available here: [https://licenses.ecosyste.ms/docs](https://licenses.ecosyste.ms/docs)
 
+The staged Go preview adds a synchronous evidence API while the Rails v1 job
+API remains available:
+
+```text
+GET /api/v2/licenses?url=https://example.test/package.tar.gz
+```
+
+The v2 response includes the archive digest, scanner corpus provenance,
+per-file detections and original-byte offsets, complete bounded attribution
+files, skipped paths, and scan errors. Its OpenAPI schema is in
+[`openapi/api/v2/openapi.yaml`](openapi/api/v2/openapi.yaml).
+
 The default rate limit for the API is 5000/req per hour based on your IP address, get in contact if you need to to increase your rate limit.
 
 ## Development

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/ecosyste-ms/licenses/internal/handler"
+	"github.com/ecosyste-ms/licenses/internal/scanner"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("server stopped", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	scanService, err := scanner.New()
+	if err != nil {
+		return err
+	}
+	if err := configureLimits(scanService); err != nil {
+		return err
+	}
+	requestTimeout, err := durationEnv("SCAN_TIMEOUT", 120*time.Second)
+	if err != nil {
+		return err
+	}
+	maxConcurrent, err := positiveIntEnv("MAX_CONCURRENT_SCANS", 4)
+	if err != nil {
+		return err
+	}
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "5000"
+	}
+	openAPIPath := os.Getenv("OPENAPI_PATH")
+	if openAPIPath == "" {
+		openAPIPath = filepath.Join("openapi", "api", "v2", "openapi.yaml")
+	}
+	application, err := handler.New(scanService, maxConcurrent, requestTimeout, openAPIPath)
+	if err != nil {
+		return err
+	}
+
+	server := &http.Server{
+		Addr:              ":" + port,
+		Handler:           application,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      requestTimeout + 10*time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 20,
+	}
+	shutdownSignals, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-shutdownSignals.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			slog.Error("graceful shutdown failed", "error", err)
+		}
+	}()
+
+	slog.Info("starting Go v2 license service", "port", port, "max_concurrent_scans", maxConcurrent)
+	err = server.ListenAndServe()
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+func positiveIntEnv(name string, fallback int) (int, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("%s must be a positive integer", name)
+	}
+	return value, nil
+}
+
+func durationEnv(name string, fallback time.Duration) (time.Duration, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := time.ParseDuration(raw)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("%s must be a positive duration", name)
+	}
+	return value, nil
+}
+
+func positiveInt64Env(name string, fallback int64) (int64, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("%s must be a positive integer", name)
+	}
+	return value, nil
+}
+
+func configureLimits(scanService *scanner.Scanner) error {
+	var err error
+	if scanService.ArchiveClient.Limits.MaxBytes, err = positiveInt64Env(
+		"MAX_DOWNLOAD_BYTES", scanService.ArchiveClient.Limits.MaxBytes,
+	); err != nil {
+		return err
+	}
+	if scanService.ExtractLimits.MaxEntries, err = positiveIntEnv(
+		"MAX_ARCHIVE_ENTRIES", scanService.ExtractLimits.MaxEntries,
+	); err != nil {
+		return err
+	}
+	if scanService.ExtractLimits.MaxDepth, err = positiveIntEnv(
+		"MAX_ARCHIVE_DEPTH", scanService.ExtractLimits.MaxDepth,
+	); err != nil {
+		return err
+	}
+	if scanService.ExtractLimits.MaxEntryBytes, err = positiveInt64Env(
+		"MAX_ENTRY_BYTES", scanService.ExtractLimits.MaxEntryBytes,
+	); err != nil {
+		return err
+	}
+	if scanService.ExtractLimits.MaxExpandedBytes, err = positiveInt64Env(
+		"MAX_EXPANDED_BYTES", scanService.ExtractLimits.MaxExpandedBytes,
+	); err != nil {
+		return err
+	}
+	if scanService.Limits.MaxFiles, err = positiveIntEnv("MAX_SCAN_FILES", scanService.Limits.MaxFiles); err != nil {
+		return err
+	}
+	if scanService.Limits.MaxDepth, err = positiveIntEnv("MAX_SCAN_DEPTH", scanService.Limits.MaxDepth); err != nil {
+		return err
+	}
+	if scanService.Limits.MaxFileBytes, err = positiveInt64Env(
+		"MAX_SCAN_FILE_BYTES", scanService.Limits.MaxFileBytes,
+	); err != nil {
+		return err
+	}
+	if scanService.Limits.Workers, err = positiveIntEnv("SCAN_WORKERS", scanService.Limits.Workers); err != nil {
+		return err
+	}
+	if scanService.Limits.MaxAttributionFiles, err = positiveIntEnv(
+		"MAX_ATTRIBUTION_FILES", scanService.Limits.MaxAttributionFiles,
+	); err != nil {
+		return err
+	}
+	if scanService.Limits.MaxAttributionBytes, err = positiveInt64Env(
+		"MAX_ATTRIBUTION_BYTES", scanService.Limits.MaxAttributionBytes,
+	); err != nil {
+		return err
+	}
+	if scanService.ExtractLimits.MaxEntryBytes > scanService.ExtractLimits.MaxExpandedBytes {
+		return errors.New("MAX_ENTRY_BYTES must not exceed MAX_EXPANDED_BYTES")
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/ecosyste-ms/licenses
+
+go 1.25.6
+
+require (
+	github.com/git-pkgs/licenses v0.2.0
+	github.com/ulikunitz/xz v0.5.16
+)
+
+require (
+	github.com/git-pkgs/spdx v0.2.0 // indirect
+	github.com/github/go-spdx/v2 v2.7.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/ecosyste-ms/licenses
 go 1.25.6
 
 require (
+	github.com/git-pkgs/archives v0.4.0
 	github.com/git-pkgs/licenses v0.2.0
+	github.com/git-pkgs/magic v0.1.0
 	github.com/ulikunitz/xz v0.5.16
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/git-pkgs/archives v0.4.0 h1:KNmmIsLiSH27lUdT27EfUkQXFaLgXV5KezE81iyOIgo=
+github.com/git-pkgs/archives v0.4.0/go.mod h1:tfio0OIuPKEBKHs/UCL5XBUvYmKpnvtnba2iDlfSd6g=
 github.com/git-pkgs/licenses v0.2.0 h1:aE5+EU6JC8n1Cb/+ed4efLD/vZ+p3FKhr9j77/UJMGI=
 github.com/git-pkgs/licenses v0.2.0/go.mod h1:imJMfsOGtGR80XMF0aXcHppzHYOJR+k9DzupNXXc0uo=
+github.com/git-pkgs/magic v0.1.0 h1:xLrqq7CMXB9g5bJnmJyKw17Rvlh0GFiEmO6e5RFsoeY=
+github.com/git-pkgs/magic v0.1.0/go.mod h1:3ndidt+yvFaI1M0aEkkzkOlFnLPkeVQASIUojazcxCI=
 github.com/git-pkgs/spdx v0.2.0 h1:kUz0ZV/AYTwCrCNH8Vtodr79Dy9vU8/G+b8grpyPR+g=
 github.com/git-pkgs/spdx v0.2.0/go.mod h1:cqRoZcvl530s/W+oGNvwjt4ODN8T1W6D/20MUZEFdto=
 github.com/github/go-spdx/v2 v2.7.0 h1:GzfXx4wFdlilARxmFRXW/mgUy3A4vSqZocCMFV6XFdQ=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/git-pkgs/licenses v0.2.0 h1:aE5+EU6JC8n1Cb/+ed4efLD/vZ+p3FKhr9j77/UJMGI=
+github.com/git-pkgs/licenses v0.2.0/go.mod h1:imJMfsOGtGR80XMF0aXcHppzHYOJR+k9DzupNXXc0uo=
+github.com/git-pkgs/spdx v0.2.0 h1:kUz0ZV/AYTwCrCNH8Vtodr79Dy9vU8/G+b8grpyPR+g=
+github.com/git-pkgs/spdx v0.2.0/go.mod h1:cqRoZcvl530s/W+oGNvwjt4ODN8T1W6D/20MUZEFdto=
+github.com/github/go-spdx/v2 v2.7.0 h1:GzfXx4wFdlilARxmFRXW/mgUy3A4vSqZocCMFV6XFdQ=
+github.com/github/go-spdx/v2 v2.7.0/go.mod h1:Ftc45YYG1WzpzwEPKRVm9Jv8vDqOrN4gWoCkK+bHer0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/ulikunitz/xz v0.5.16 h1:ld6NyySjx5lowVKwJvMRLnW5nxKX/xnpSiFYZ/Lxur0=
+github.com/ulikunitz/xz v0.5.16/go.mod h1:H9Rt/W6/Qj27PGauhQc6nfCDy7vHpzsOThBSaYDoEhw=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/archive/client.go
+++ b/internal/archive/client.go
@@ -1,0 +1,237 @@
+package archive
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const userAgent = "licenses.ecosyste.ms/v2"
+
+// DownloadLimits bounds remote archive requests.
+type DownloadLimits struct {
+	MaxBytes       int64
+	MaxRedirects   int
+	ConnectTimeout time.Duration
+	HeaderTimeout  time.Duration
+	RequestTimeout time.Duration
+}
+
+// DefaultDownloadLimits returns conservative production defaults.
+func DefaultDownloadLimits() DownloadLimits {
+	return DownloadLimits{
+		MaxBytes:       100 << 20,
+		MaxRedirects:   5,
+		ConnectTimeout: 10 * time.Second,
+		HeaderTimeout:  20 * time.Second,
+		RequestTimeout: 60 * time.Second,
+	}
+}
+
+// Client downloads archives. HTTPClient is injectable for local fixture
+// servers; production should use NewSafeHTTPClient.
+type Client struct {
+	HTTPClient        *http.Client
+	Limits            DownloadLimits
+	AllowPrivateHosts bool // Test fixtures only; production must leave this false.
+}
+
+// NewClient constructs a production client that blocks non-public networks.
+func NewClient(limits DownloadLimits) *Client {
+	return &Client{HTTPClient: NewSafeHTTPClient(limits), Limits: limits}
+}
+
+// NewSafeHTTPClient returns an HTTP client whose dialer validates every
+// resolved address and whose redirect policy revalidates every destination.
+func NewSafeHTTPClient(limits DownloadLimits) *http.Client {
+	dialer := &net.Dialer{Timeout: limits.ConnectTimeout, KeepAlive: 30 * time.Second}
+	transport := &http.Transport{
+		DialContext:           safeDialContext(dialer),
+		ForceAttemptHTTP2:     true,
+		TLSHandshakeTimeout:   limits.ConnectTimeout,
+		ResponseHeaderTimeout: limits.HeaderTimeout,
+		IdleConnTimeout:       90 * time.Second,
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   limits.RequestTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= limits.MaxRedirects {
+				return errors.New("redirect limit exceeded")
+			}
+			if err := ValidateURL(req.URL); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+func safeDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return validatedDialContext(net.DefaultResolver.LookupNetIP, dialer.DialContext)
+}
+
+func validatedDialContext(
+	lookup func(context.Context, string, string) ([]netip.Addr, error),
+	dial func(context.Context, string, string) (net.Conn, error),
+) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, fmt.Errorf("invalid destination: %w", err)
+		}
+		addresses, err := lookup(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("resolving destination: %w", err)
+		}
+		if len(addresses) == 0 {
+			return nil, errors.New("destination has no addresses")
+		}
+		for _, address := range addresses {
+			if !IsPublicIP(address.Unmap()) {
+				return nil, fmt.Errorf("destination resolves to blocked address %s", address)
+			}
+		}
+		var lastErr error
+		for _, resolved := range addresses {
+			conn, err := dial(ctx, network, net.JoinHostPort(resolved.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		return nil, lastErr
+	}
+}
+
+// IsPublicIP reports whether addr is safe for a user-selected remote request.
+func IsPublicIP(addr netip.Addr) bool {
+	if !addr.IsValid() || addr.IsUnspecified() || addr.IsLoopback() ||
+		addr.IsPrivate() || addr.IsLinkLocalUnicast() ||
+		addr.IsMulticast() || addr.IsInterfaceLocalMulticast() {
+		return false
+	}
+	// RFC 6598 shared address space is not considered globally reachable by
+	// netip, but spell it out to keep this boundary obvious.
+	if prefix := netip.MustParsePrefix("100.64.0.0/10"); prefix.Contains(addr) {
+		return false
+	}
+	return addr.IsGlobalUnicast()
+}
+
+// ValidateURL validates the URL shape before any network activity.
+func ValidateURL(parsed *url.URL) error {
+	if err := validateURLShape(parsed); err != nil {
+		return err
+	}
+	if ip, err := netip.ParseAddr(strings.Trim(parsed.Hostname(), "[]")); err == nil && !IsPublicIP(ip.Unmap()) {
+		return errors.New("URL address is not public")
+	}
+	return nil
+}
+
+func validateURLShape(parsed *url.URL) error {
+	if parsed == nil {
+		return errors.New("URL is required")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return errors.New("only HTTP and HTTPS URLs are supported")
+	}
+	if parsed.Hostname() == "" {
+		return errors.New("URL hostname is required")
+	}
+	if parsed.User != nil {
+		return errors.New("URL credentials are not allowed")
+	}
+	if port := parsed.Port(); port != "" {
+		value, err := strconv.ParseUint(port, 10, 16)
+		if err != nil || value == 0 {
+			return errors.New("URL port is invalid")
+		}
+	}
+	return nil
+}
+
+// Download streams rawURL into destination and returns the content SHA-256.
+func (c *Client) Download(ctx context.Context, rawURL, destination string) (string, error) {
+	if c == nil || c.HTTPClient == nil {
+		return "", wrap(KindDownload, "download", errors.New("HTTP client is not configured"))
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", wrap(KindInvalid, "validate URL", err)
+	}
+	validate := ValidateURL
+	if c.AllowPrivateHosts {
+		validate = validateURLShape
+	}
+	if err := validate(parsed); err != nil {
+		return "", wrap(KindInvalid, "validate URL", err)
+	}
+	if c.Limits.MaxBytes <= 0 {
+		return "", wrap(KindInvalid, "validate limits", errors.New("download byte limit must be positive"))
+	}
+
+	requestCtx := ctx
+	var cancel context.CancelFunc
+	if c.Limits.RequestTimeout > 0 {
+		requestCtx, cancel = context.WithTimeout(ctx, c.Limits.RequestTimeout)
+		defer cancel()
+	}
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return "", wrap(KindInvalid, "create request", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/octet-stream, application/zip, application/gzip, application/x-tar")
+	req.Header.Set("Accept-Encoding", "identity")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return "", wrap(KindDownload, "download archive", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", wrap(KindDownload, "download archive", fmt.Errorf("upstream returned HTTP %d", resp.StatusCode))
+	}
+	if resp.ContentLength > c.Limits.MaxBytes {
+		return "", wrap(KindLimit, "download archive", fmt.Errorf("compressed archive exceeds %d bytes", c.Limits.MaxBytes))
+	}
+
+	file, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return "", wrap(KindDownload, "create archive file", err)
+	}
+	remove := true
+	defer func() {
+		_ = file.Close()
+		if remove {
+			_ = os.Remove(destination)
+		}
+	}()
+
+	hash := sha256.New()
+	written, err := io.Copy(io.MultiWriter(file, hash), io.LimitReader(resp.Body, c.Limits.MaxBytes+1))
+	if err != nil {
+		return "", wrap(KindDownload, "read archive", err)
+	}
+	if written > c.Limits.MaxBytes {
+		return "", wrap(KindLimit, "download archive", fmt.Errorf("compressed archive exceeds %d bytes", c.Limits.MaxBytes))
+	}
+	if err := file.Sync(); err != nil {
+		return "", wrap(KindDownload, "sync archive", err)
+	}
+	remove = false
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/internal/archive/client_test.go
+++ b/internal/archive/client_test.go
@@ -1,0 +1,165 @@
+package archive
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsPublicIP(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		address string
+		want    bool
+	}{
+		{address: "8.8.8.8", want: true},
+		{address: "2606:4700:4700::1111", want: true},
+		{address: "127.0.0.1", want: false},
+		{address: "10.1.2.3", want: false},
+		{address: "169.254.169.254", want: false},
+		{address: "100.64.0.1", want: false},
+		{address: "::1", want: false},
+		{address: "fe80::1", want: false},
+		{address: "ff02::1", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.address, func(t *testing.T) {
+			if got := IsPublicIP(netip.MustParseAddr(test.address)); got != test.want {
+				t.Fatalf("IsPublicIP(%s) = %v, want %v", test.address, got, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		raw  string
+		want bool
+	}{
+		{raw: "https://example.com/package.tgz", want: true},
+		{raw: "ftp://example.com/package.tgz"},
+		{raw: "https:///package.tgz"},
+		{raw: "https://user:pass@example.com/package.tgz"},
+		{raw: "http://127.0.0.1/package.tgz"},
+		{raw: "http://[::1]/package.tgz"},
+		{raw: "http://example.com:0/package.tgz"},
+	}
+	for _, test := range tests {
+		t.Run(test.raw, func(t *testing.T) {
+			parsed, err := url.Parse(test.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := ValidateURL(parsed) == nil; got != test.want {
+				t.Fatalf("ValidateURL(%q) success = %v, want %v", test.raw, got, test.want)
+			}
+		})
+	}
+}
+
+func TestSafeClientRejectsPrivateRedirect(t *testing.T) {
+	t.Parallel()
+	client := NewSafeHTTPClient(DefaultDownloadLimits())
+	request := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/archive.zip", nil)
+	if err := client.CheckRedirect(request, []*http.Request{{}}); err == nil {
+		t.Fatal("private redirect was accepted")
+	}
+}
+
+func TestValidatedDialRejectsMixedDNSAnswersBeforeConnecting(t *testing.T) {
+	t.Parallel()
+	lookup := func(context.Context, string, string) ([]netip.Addr, error) {
+		return []netip.Addr{
+			netip.MustParseAddr("8.8.8.8"),
+			netip.MustParseAddr("127.0.0.1"),
+		}, nil
+	}
+	called := false
+	dial := func(context.Context, string, string) (net.Conn, error) {
+		called = true
+		return nil, nil
+	}
+	_, err := validatedDialContext(lookup, dial)(context.Background(), "tcp", "rebinding.test:443")
+	if err == nil {
+		t.Fatal("mixed public/private DNS response was accepted")
+	}
+	if called {
+		t.Fatal("dial was attempted before every DNS answer was validated")
+	}
+}
+
+func TestDownload(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != userAgent {
+			t.Errorf("User-Agent = %q, want %q", got, userAgent)
+		}
+		_, _ = io.WriteString(w, "archive bytes")
+	}))
+	defer server.Close()
+	limits := DefaultDownloadLimits()
+	client := &Client{
+		HTTPClient: server.Client(), Limits: limits, AllowPrivateHosts: true,
+	}
+	destination := filepath.Join(t.TempDir(), "archive")
+	digest, err := client.Download(context.Background(), server.URL, destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digest != "cc9c340301ad4ba5e54aa24b442ff938d1ed84f7f32c4c5a73773c58af37bd1b" {
+		t.Fatalf("digest = %q", digest)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "archive bytes" {
+		t.Fatalf("downloaded %q", data)
+	}
+}
+
+func TestDownloadLimit(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "9")
+		_, _ = io.WriteString(w, strings.Repeat("x", 9))
+	}))
+	defer server.Close()
+	limits := DefaultDownloadLimits()
+	limits.MaxBytes = 8
+	client := &Client{HTTPClient: server.Client(), Limits: limits, AllowPrivateHosts: true}
+	destination := filepath.Join(t.TempDir(), "archive")
+	_, err := client.Download(context.Background(), server.URL, destination)
+	if KindOf(err) != KindLimit {
+		t.Fatalf("error = %v, kind = %q", err, KindOf(err))
+	}
+	if _, statErr := os.Stat(destination); !os.IsNotExist(statErr) {
+		t.Fatalf("partial destination remains: %v", statErr)
+	}
+}
+
+func TestDownloadTimeout(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-time.After(100 * time.Millisecond)
+		_, _ = io.WriteString(w, "late")
+	}))
+	defer server.Close()
+	limits := DefaultDownloadLimits()
+	limits.RequestTimeout = 10 * time.Millisecond
+	client := &Client{HTTPClient: server.Client(), Limits: limits, AllowPrivateHosts: true}
+	_, err := client.Download(context.Background(), server.URL, filepath.Join(t.TempDir(), "archive"))
+	if KindOf(err) != KindDownload {
+		t.Fatalf("error = %v, kind = %q", err, KindOf(err))
+	}
+}

--- a/internal/archive/errors.go
+++ b/internal/archive/errors.go
@@ -1,0 +1,54 @@
+package archive
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrorKind identifies failures that callers need to map to an HTTP status.
+type ErrorKind string
+
+const (
+	KindInvalid     ErrorKind = "invalid"
+	KindUnsupported ErrorKind = "unsupported"
+	KindLimit       ErrorKind = "limit"
+	KindDownload    ErrorKind = "download"
+	KindExtract     ErrorKind = "extract"
+)
+
+// Error is a safe, classified archive-processing error.
+type Error struct {
+	Kind ErrorKind
+	Op   string
+	Err  error
+}
+
+func (e *Error) Error() string {
+	if e.Op == "" {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("%s: %v", e.Op, e.Err)
+}
+
+func (e *Error) Unwrap() error { return e.Err }
+
+func wrap(kind ErrorKind, op string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var classified *Error
+	if errors.As(err, &classified) {
+		return err
+	}
+	return &Error{Kind: kind, Op: op, Err: err}
+}
+
+// KindOf returns the classification of err, or the empty string for an
+// unclassified error.
+func KindOf(err error) ErrorKind {
+	var classified *Error
+	if errors.As(err, &classified) {
+		return classified.Kind
+	}
+	return ""
+}

--- a/internal/archive/extract.go
+++ b/internal/archive/extract.go
@@ -1,0 +1,458 @@
+package archive
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/ulikunitz/xz"
+)
+
+// ExtractLimits bounds archive expansion before scanning begins.
+type ExtractLimits struct {
+	MaxEntries       int
+	MaxDepth         int
+	MaxEntryBytes    int64
+	MaxExpandedBytes int64
+}
+
+// DefaultExtractLimits returns production extraction limits.
+func DefaultExtractLimits() ExtractLimits {
+	return ExtractLimits{
+		MaxEntries:       10_000,
+		MaxDepth:         64,
+		MaxEntryBytes:    32 << 20,
+		MaxExpandedBytes: 512 << 20,
+	}
+}
+
+// Skip records an archive member deliberately excluded from extraction.
+type Skip struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+// ExtractResult describes a safe extraction root and excluded entries.
+type ExtractResult struct {
+	Root    string
+	Skipped []Skip
+}
+
+type extractBudget struct {
+	limits   ExtractLimits
+	entries  int
+	expanded int64
+}
+
+// Extract expands archivePath beneath destination and returns the scan root.
+// ZIP/JAR, tar, tar.gz, tar.xz, and Ruby gem containers are supported.
+func Extract(ctx context.Context, archivePath, destination string, limits ExtractLimits) (ExtractResult, error) {
+	if err := validateExtractLimits(limits); err != nil {
+		return ExtractResult{}, wrap(KindInvalid, "validate extraction limits", err)
+	}
+	if err := os.MkdirAll(destination, 0o700); err != nil {
+		return ExtractResult{}, wrap(KindExtract, "create extraction root", err)
+	}
+	format, err := detectFormat(archivePath)
+	if err != nil {
+		return ExtractResult{}, err
+	}
+	budget := &extractBudget{limits: limits}
+	root := filepath.Join(destination, "contents")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		return ExtractResult{}, wrap(KindExtract, "create contents directory", err)
+	}
+
+	var files []string
+	var skipped []Skip
+	switch format {
+	case "zip":
+		files, skipped, err = extractZIP(ctx, archivePath, root, budget)
+	case "tar":
+		files, skipped, err = extractTarFile(ctx, archivePath, root, budget, "tar")
+	case "tar.gz":
+		files, skipped, err = extractTarFile(ctx, archivePath, root, budget, "gzip")
+	case "tar.xz":
+		files, skipped, err = extractTarFile(ctx, archivePath, root, budget, "xz")
+	default:
+		panic("unreachable archive format")
+	}
+	if err != nil {
+		return ExtractResult{}, err
+	}
+
+	// Ruby gems are tar files containing metadata.gz and data.tar.gz. Scan the
+	// package payload rather than the gem container metadata.
+	if format == "tar" && slices.Contains(files, "data.tar.gz") && slices.Contains(files, "metadata.gz") {
+		gemRoot := filepath.Join(destination, "gem-contents")
+		if err := os.Mkdir(gemRoot, 0o700); err != nil {
+			return ExtractResult{}, wrap(KindExtract, "create gem contents directory", err)
+		}
+		innerFiles, innerSkipped, innerErr := extractTarFile(
+			ctx,
+			filepath.Join(root, filepath.FromSlash("data.tar.gz")),
+			gemRoot,
+			budget,
+			"gzip",
+		)
+		if innerErr != nil {
+			return ExtractResult{}, innerErr
+		}
+		files = innerFiles
+		skipped = append(skipped, innerSkipped...)
+		root = gemRoot
+	}
+
+	if len(files) == 0 {
+		return ExtractResult{}, wrap(KindInvalid, "extract archive", errors.New("archive contains no regular files"))
+	}
+	root = commonRoot(root, files)
+	slices.SortFunc(skipped, func(a, b Skip) int {
+		if compared := strings.Compare(a.Path, b.Path); compared != 0 {
+			return compared
+		}
+		return strings.Compare(a.Reason, b.Reason)
+	})
+	return ExtractResult{Root: root, Skipped: skipped}, nil
+}
+
+func validateExtractLimits(limits ExtractLimits) error {
+	if limits.MaxEntries <= 0 || limits.MaxDepth <= 0 ||
+		limits.MaxEntryBytes <= 0 || limits.MaxExpandedBytes <= 0 {
+		return errors.New("all extraction limits must be positive")
+	}
+	if limits.MaxEntryBytes > limits.MaxExpandedBytes {
+		return errors.New("entry limit must not exceed expanded-byte limit")
+	}
+	return nil
+}
+
+func detectFormat(archivePath string) (string, error) {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return "", wrap(KindExtract, "open archive", err)
+	}
+	defer file.Close()
+	header := make([]byte, 512)
+	n, err := io.ReadFull(file, header)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return "", wrap(KindExtract, "read archive header", err)
+	}
+	header = header[:n]
+	switch {
+	case bytes.HasPrefix(header, []byte{'P', 'K', 3, 4}),
+		bytes.HasPrefix(header, []byte{'P', 'K', 5, 6}),
+		bytes.HasPrefix(header, []byte{'P', 'K', 7, 8}):
+		return "zip", nil
+	case bytes.HasPrefix(header, []byte{0x1f, 0x8b}):
+		return "tar.gz", nil
+	case bytes.HasPrefix(header, []byte{0xfd, '7', 'z', 'X', 'Z', 0x00}):
+		return "tar.xz", nil
+	case len(header) >= 265 && bytes.Equal(header[257:262], []byte("ustar")):
+		return "tar", nil
+	default:
+		if len(header) == 512 {
+			if _, tarErr := tar.NewReader(bytes.NewReader(header)).Next(); tarErr == nil {
+				return "tar", nil
+			}
+		}
+		return "", wrap(KindUnsupported, "detect archive", errors.New("unsupported archive format"))
+	}
+}
+
+func extractZIP(
+	ctx context.Context,
+	archivePath string,
+	destination string,
+	budget *extractBudget,
+) ([]string, []Skip, error) {
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return nil, nil, wrap(KindInvalid, "open ZIP archive", err)
+	}
+	defer reader.Close()
+	var files []string
+	var skipped []Skip
+	for _, member := range reader.File {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		if err := budget.nextEntry(); err != nil {
+			return nil, nil, err
+		}
+		name, err := safeMemberName(member.Name, budget.limits.MaxDepth)
+		if err != nil {
+			return nil, nil, err
+		}
+		if name == "" {
+			continue
+		}
+		mode := member.Mode()
+		switch {
+		case member.FileInfo().IsDir():
+			if err := makeDirectory(destination, name); err != nil {
+				return nil, nil, err
+			}
+		case mode&os.ModeSymlink != 0:
+			skipped = append(skipped, Skip{Path: name, Reason: "symlink"})
+		case !mode.IsRegular():
+			skipped = append(skipped, Skip{Path: name, Reason: "non-regular"})
+		default:
+			if member.UncompressedSize64 > uint64(budget.limits.MaxEntryBytes) {
+				return nil, nil, wrap(KindLimit, "extract ZIP member", fmt.Errorf("%s exceeds the per-entry limit", name))
+			}
+			source, err := member.Open()
+			if err != nil {
+				return nil, nil, wrap(KindInvalid, "open ZIP member", err)
+			}
+			err = extractRegularFile(ctx, source, destination, name, budget)
+			_ = source.Close()
+			if err != nil {
+				return nil, nil, err
+			}
+			files = append(files, name)
+		}
+	}
+	return files, skipped, nil
+}
+
+func extractTarFile(
+	ctx context.Context,
+	archivePath string,
+	destination string,
+	budget *extractBudget,
+	compression string,
+) ([]string, []Skip, error) {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return nil, nil, wrap(KindExtract, "open tar archive", err)
+	}
+	defer file.Close()
+	var source io.Reader = bufio.NewReader(file)
+	var gzipReader *gzip.Reader
+	switch compression {
+	case "gzip":
+		gzipReader, err = gzip.NewReader(source)
+		if err != nil {
+			return nil, nil, wrap(KindInvalid, "open gzip stream", err)
+		}
+		defer gzipReader.Close()
+		source = gzipReader
+	case "xz":
+		xzReader, xzErr := xz.NewReader(source)
+		if xzErr != nil {
+			return nil, nil, wrap(KindInvalid, "open xz stream", xzErr)
+		}
+		source = xzReader
+	case "tar":
+	default:
+		panic("unknown tar compression")
+	}
+	source = &contextReader{ctx: ctx, source: source}
+	return extractTarReader(ctx, tar.NewReader(source), destination, budget)
+}
+
+func extractTarReader(
+	ctx context.Context,
+	reader *tar.Reader,
+	destination string,
+	budget *extractBudget,
+) ([]string, []Skip, error) {
+	var files []string
+	var skipped []Skip
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, nil, wrap(KindInvalid, "read tar header", err)
+		}
+		if err := budget.nextEntry(); err != nil {
+			return nil, nil, err
+		}
+		name, err := safeMemberName(header.Name, budget.limits.MaxDepth)
+		if err != nil {
+			return nil, nil, err
+		}
+		if name == "" {
+			continue
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := makeDirectory(destination, name); err != nil {
+				return nil, nil, err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if header.Size < 0 || header.Size > budget.limits.MaxEntryBytes {
+				return nil, nil, wrap(KindLimit, "extract tar member", fmt.Errorf("%s exceeds the per-entry limit", name))
+			}
+			if err := extractRegularFile(ctx, reader, destination, name, budget); err != nil {
+				return nil, nil, err
+			}
+			files = append(files, name)
+		case tar.TypeSymlink:
+			skipped = append(skipped, Skip{Path: name, Reason: "symlink"})
+		case tar.TypeLink:
+			skipped = append(skipped, Skip{Path: name, Reason: "hard-link"})
+		default:
+			skipped = append(skipped, Skip{Path: name, Reason: "non-regular"})
+		}
+	}
+	return files, skipped, nil
+}
+
+func (b *extractBudget) nextEntry() error {
+	b.entries++
+	if b.entries > b.limits.MaxEntries {
+		return wrap(KindLimit, "extract archive", fmt.Errorf("archive exceeds %d entries", b.limits.MaxEntries))
+	}
+	return nil
+}
+
+func safeMemberName(raw string, maxDepth int) (string, error) {
+	if strings.ContainsRune(raw, 0) {
+		return "", wrap(KindInvalid, "validate archive path", errors.New("member path contains NUL"))
+	}
+	raw = strings.ReplaceAll(raw, "\\", "/")
+	if strings.HasPrefix(raw, "/") {
+		return "", wrap(KindInvalid, "validate archive path", fmt.Errorf("absolute member path %q", raw))
+	}
+	if len(raw) >= 2 && ((raw[0] >= 'a' && raw[0] <= 'z') || (raw[0] >= 'A' && raw[0] <= 'Z')) && raw[1] == ':' {
+		return "", wrap(KindInvalid, "validate archive path", fmt.Errorf("drive-qualified member path %q", raw))
+	}
+	cleaned := path.Clean(raw)
+	if cleaned == "." {
+		return "", nil
+	}
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", wrap(KindInvalid, "validate archive path", fmt.Errorf("traversal member path %q", raw))
+	}
+	if depth := strings.Count(cleaned, "/") + 1; depth > maxDepth {
+		return "", wrap(KindLimit, "validate archive path", fmt.Errorf("member path exceeds depth %d", maxDepth))
+	}
+	return cleaned, nil
+}
+
+func destinationPath(root, name string) (string, error) {
+	target := filepath.Join(root, filepath.FromSlash(name))
+	relative, err := filepath.Rel(root, target)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", wrap(KindInvalid, "validate extraction target", fmt.Errorf("member escapes extraction root: %s", name))
+	}
+	return target, nil
+}
+
+func makeDirectory(root, name string) error {
+	target, err := destinationPath(root, name)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		return wrap(KindExtract, "create archive directory", err)
+	}
+	return nil
+}
+
+func extractRegularFile(
+	ctx context.Context,
+	source io.Reader,
+	root string,
+	name string,
+	budget *extractBudget,
+) error {
+	target, err := destinationPath(root, name)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		return wrap(KindExtract, "create member directory", err)
+	}
+	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return wrap(KindInvalid, "create archive member", err)
+	}
+	keep := false
+	defer func() {
+		_ = file.Close()
+		if !keep {
+			_ = os.Remove(target)
+		}
+	}()
+
+	writer := &budgetWriter{target: file, budget: budget}
+	read := &contextReader{ctx: ctx, source: io.LimitReader(source, budget.limits.MaxEntryBytes+1)}
+	written, err := io.Copy(writer, read)
+	if err != nil {
+		return err
+	}
+	if written > budget.limits.MaxEntryBytes {
+		return wrap(KindLimit, "extract archive member", fmt.Errorf("%s exceeds the per-entry limit", name))
+	}
+	if err := file.Close(); err != nil {
+		return wrap(KindExtract, "close archive member", err)
+	}
+	keep = true
+	return nil
+}
+
+type contextReader struct {
+	ctx    context.Context
+	source io.Reader
+}
+
+func (r *contextReader) Read(buffer []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.source.Read(buffer)
+}
+
+type budgetWriter struct {
+	target io.Writer
+	budget *extractBudget
+}
+
+func (w *budgetWriter) Write(buffer []byte) (int, error) {
+	if int64(len(buffer)) > w.budget.limits.MaxExpandedBytes-w.budget.expanded {
+		return 0, wrap(KindLimit, "extract archive", fmt.Errorf("expanded data exceeds %d bytes", w.budget.limits.MaxExpandedBytes))
+	}
+	n, err := w.target.Write(buffer)
+	w.budget.expanded += int64(n)
+	return n, err
+}
+
+func commonRoot(root string, files []string) string {
+	if len(files) == 0 {
+		return root
+	}
+	var common string
+	for _, name := range files {
+		parts := strings.Split(name, "/")
+		if len(parts) < 2 {
+			return root
+		}
+		if common == "" {
+			common = parts[0]
+			continue
+		}
+		if parts[0] != common {
+			return root
+		}
+	}
+	return filepath.Join(root, filepath.FromSlash(common))
+}

--- a/internal/archive/extract.go
+++ b/internal/archive/extract.go
@@ -1,11 +1,6 @@
 package archive
 
 import (
-	"archive/tar"
-	"archive/zip"
-	"bufio"
-	"bytes"
-	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -16,7 +11,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/ulikunitz/xz"
+	archives "github.com/git-pkgs/archives"
 )
 
 // ExtractLimits bounds archive expansion before scanning begins.
@@ -61,13 +56,29 @@ func Extract(ctx context.Context, archivePath, destination string, limits Extrac
 	if err := validateExtractLimits(limits); err != nil {
 		return ExtractResult{}, wrap(KindInvalid, "validate extraction limits", err)
 	}
+	if err := ctx.Err(); err != nil {
+		return ExtractResult{}, err
+	}
 	if err := os.MkdirAll(destination, 0o700); err != nil {
 		return ExtractResult{}, wrap(KindExtract, "create extraction root", err)
 	}
-	format, err := detectFormat(archivePath)
+	reader, members, err := openArchive(ctx, archivePath, filepath.Base(archivePath))
 	if err != nil {
 		return ExtractResult{}, err
 	}
+	defer func() { _ = reader.Close() }()
+
+	// A Ruby gem is a tar envelope containing data.tar.gz. The downloaded
+	// temporary file has no useful extension, so reopen that envelope with the
+	// semantic name expected by git-pkgs/archives after inspecting its listing.
+	if isGemEnvelope(members) {
+		_ = reader.Close()
+		reader, members, err = openArchive(ctx, archivePath, "archive.gem")
+		if err != nil {
+			return ExtractResult{}, err
+		}
+	}
+
 	budget := &extractBudget{limits: limits}
 	root := filepath.Join(destination, "contents")
 	if err := os.Mkdir(root, 0o700); err != nil {
@@ -76,42 +87,56 @@ func Extract(ctx context.Context, archivePath, destination string, limits Extrac
 
 	var files []string
 	var skipped []Skip
-	switch format {
-	case "zip":
-		files, skipped, err = extractZIP(ctx, archivePath, root, budget)
-	case "tar":
-		files, skipped, err = extractTarFile(ctx, archivePath, root, budget, "tar")
-	case "tar.gz":
-		files, skipped, err = extractTarFile(ctx, archivePath, root, budget, "gzip")
-	case "tar.xz":
-		files, skipped, err = extractTarFile(ctx, archivePath, root, budget, "xz")
-	default:
-		panic("unreachable archive format")
-	}
-	if err != nil {
-		return ExtractResult{}, err
-	}
+	for _, member := range members {
+		if err := ctx.Err(); err != nil {
+			return ExtractResult{}, err
+		}
+		if err := budget.nextEntry(); err != nil {
+			return ExtractResult{}, err
+		}
+		name, err := safeMemberName(member.Path, limits.MaxDepth)
+		if err != nil {
+			return ExtractResult{}, err
+		}
+		if name == "" || member.IsDir {
+			continue
+		}
 
-	// Ruby gems are tar files containing metadata.gz and data.tar.gz. Scan the
-	// package payload rather than the gem container metadata.
-	if format == "tar" && slices.Contains(files, "data.tar.gz") && slices.Contains(files, "metadata.gz") {
-		gemRoot := filepath.Join(destination, "gem-contents")
-		if err := os.Mkdir(gemRoot, 0o700); err != nil {
-			return ExtractResult{}, wrap(KindExtract, "create gem contents directory", err)
+		mode := os.FileMode(member.Mode)
+		switch {
+		case mode&os.ModeSymlink != 0:
+			skipped = append(skipped, Skip{Path: name, Reason: "symlink"})
+			continue
+		case !mode.IsRegular():
+			skipped = append(skipped, Skip{Path: name, Reason: "non-regular"})
+			continue
+		case member.Size == 0:
+			// Empty files cannot contain license evidence. This also prevents
+			// tar link and device records, whose type is intentionally not
+			// materialized by git-pkgs/archives, from becoming filesystem files.
+			skipped = append(skipped, Skip{Path: name, Reason: "empty"})
+			continue
+		case member.Size < 0 || member.Size > limits.MaxEntryBytes:
+			return ExtractResult{}, wrap(
+				KindLimit,
+				"extract archive member",
+				fmt.Errorf("%s exceeds the per-entry limit", name),
+			)
 		}
-		innerFiles, innerSkipped, innerErr := extractTarFile(
-			ctx,
-			filepath.Join(root, filepath.FromSlash("data.tar.gz")),
-			gemRoot,
-			budget,
-			"gzip",
-		)
-		if innerErr != nil {
-			return ExtractResult{}, innerErr
+
+		source, err := reader.Extract(member.Path)
+		if err != nil {
+			return ExtractResult{}, wrap(KindInvalid, "open archive member", err)
 		}
-		files = innerFiles
-		skipped = append(skipped, innerSkipped...)
-		root = gemRoot
+		extractErr := extractRegularFile(ctx, source, root, name, budget)
+		closeErr := source.Close()
+		if extractErr != nil {
+			return ExtractResult{}, extractErr
+		}
+		if closeErr != nil {
+			return ExtractResult{}, wrap(KindExtract, "close archive member", closeErr)
+		}
+		files = append(files, name)
 	}
 
 	if len(files) == 0 {
@@ -127,6 +152,53 @@ func Extract(ctx context.Context, archivePath, destination string, limits Extrac
 	return ExtractResult{Root: root, Skipped: skipped}, nil
 }
 
+func openArchive(
+	ctx context.Context,
+	archivePath string,
+	name string,
+) (archives.Reader, []archives.FileInfo, error) {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return nil, nil, wrap(KindExtract, "open archive", err)
+	}
+	reader, err := archives.Open(name, &contextReader{ctx: ctx, source: file})
+	_ = file.Close()
+	if err != nil {
+		return nil, nil, archiveOpenError(err)
+	}
+	members, err := reader.List()
+	if err != nil {
+		_ = reader.Close()
+		return nil, nil, archiveOpenError(err)
+	}
+	return reader, members, nil
+}
+
+func archiveOpenError(err error) error {
+	if errors.Is(err, archives.ErrDecompressLimit) {
+		return wrap(KindLimit, "open archive", err)
+	}
+	if strings.Contains(err.Error(), "unsupported archive format") ||
+		strings.Contains(err.Error(), "unsupported format") {
+		return wrap(KindUnsupported, "open archive", err)
+	}
+	return wrap(KindInvalid, "open archive", err)
+}
+
+func isGemEnvelope(members []archives.FileInfo) bool {
+	metadata := false
+	payload := false
+	for _, member := range members {
+		switch path.Clean(strings.ReplaceAll(member.Path, "\\", "/")) {
+		case "metadata.gz":
+			metadata = true
+		case "data.tar.gz":
+			payload = true
+		}
+	}
+	return metadata && payload
+}
+
 func validateExtractLimits(limits ExtractLimits) error {
 	if limits.MaxEntries <= 0 || limits.MaxDepth <= 0 ||
 		limits.MaxEntryBytes <= 0 || limits.MaxExpandedBytes <= 0 {
@@ -136,184 +208,6 @@ func validateExtractLimits(limits ExtractLimits) error {
 		return errors.New("entry limit must not exceed expanded-byte limit")
 	}
 	return nil
-}
-
-func detectFormat(archivePath string) (string, error) {
-	file, err := os.Open(archivePath)
-	if err != nil {
-		return "", wrap(KindExtract, "open archive", err)
-	}
-	defer file.Close()
-	header := make([]byte, 512)
-	n, err := io.ReadFull(file, header)
-	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
-		return "", wrap(KindExtract, "read archive header", err)
-	}
-	header = header[:n]
-	switch {
-	case bytes.HasPrefix(header, []byte{'P', 'K', 3, 4}),
-		bytes.HasPrefix(header, []byte{'P', 'K', 5, 6}),
-		bytes.HasPrefix(header, []byte{'P', 'K', 7, 8}):
-		return "zip", nil
-	case bytes.HasPrefix(header, []byte{0x1f, 0x8b}):
-		return "tar.gz", nil
-	case bytes.HasPrefix(header, []byte{0xfd, '7', 'z', 'X', 'Z', 0x00}):
-		return "tar.xz", nil
-	case len(header) >= 265 && bytes.Equal(header[257:262], []byte("ustar")):
-		return "tar", nil
-	default:
-		if len(header) == 512 {
-			if _, tarErr := tar.NewReader(bytes.NewReader(header)).Next(); tarErr == nil {
-				return "tar", nil
-			}
-		}
-		return "", wrap(KindUnsupported, "detect archive", errors.New("unsupported archive format"))
-	}
-}
-
-func extractZIP(
-	ctx context.Context,
-	archivePath string,
-	destination string,
-	budget *extractBudget,
-) ([]string, []Skip, error) {
-	reader, err := zip.OpenReader(archivePath)
-	if err != nil {
-		return nil, nil, wrap(KindInvalid, "open ZIP archive", err)
-	}
-	defer reader.Close()
-	var files []string
-	var skipped []Skip
-	for _, member := range reader.File {
-		if err := ctx.Err(); err != nil {
-			return nil, nil, err
-		}
-		if err := budget.nextEntry(); err != nil {
-			return nil, nil, err
-		}
-		name, err := safeMemberName(member.Name, budget.limits.MaxDepth)
-		if err != nil {
-			return nil, nil, err
-		}
-		if name == "" {
-			continue
-		}
-		mode := member.Mode()
-		switch {
-		case member.FileInfo().IsDir():
-			if err := makeDirectory(destination, name); err != nil {
-				return nil, nil, err
-			}
-		case mode&os.ModeSymlink != 0:
-			skipped = append(skipped, Skip{Path: name, Reason: "symlink"})
-		case !mode.IsRegular():
-			skipped = append(skipped, Skip{Path: name, Reason: "non-regular"})
-		default:
-			if member.UncompressedSize64 > uint64(budget.limits.MaxEntryBytes) {
-				return nil, nil, wrap(KindLimit, "extract ZIP member", fmt.Errorf("%s exceeds the per-entry limit", name))
-			}
-			source, err := member.Open()
-			if err != nil {
-				return nil, nil, wrap(KindInvalid, "open ZIP member", err)
-			}
-			err = extractRegularFile(ctx, source, destination, name, budget)
-			_ = source.Close()
-			if err != nil {
-				return nil, nil, err
-			}
-			files = append(files, name)
-		}
-	}
-	return files, skipped, nil
-}
-
-func extractTarFile(
-	ctx context.Context,
-	archivePath string,
-	destination string,
-	budget *extractBudget,
-	compression string,
-) ([]string, []Skip, error) {
-	file, err := os.Open(archivePath)
-	if err != nil {
-		return nil, nil, wrap(KindExtract, "open tar archive", err)
-	}
-	defer file.Close()
-	var source io.Reader = bufio.NewReader(file)
-	var gzipReader *gzip.Reader
-	switch compression {
-	case "gzip":
-		gzipReader, err = gzip.NewReader(source)
-		if err != nil {
-			return nil, nil, wrap(KindInvalid, "open gzip stream", err)
-		}
-		defer gzipReader.Close()
-		source = gzipReader
-	case "xz":
-		xzReader, xzErr := xz.NewReader(source)
-		if xzErr != nil {
-			return nil, nil, wrap(KindInvalid, "open xz stream", xzErr)
-		}
-		source = xzReader
-	case "tar":
-	default:
-		panic("unknown tar compression")
-	}
-	source = &contextReader{ctx: ctx, source: source}
-	return extractTarReader(ctx, tar.NewReader(source), destination, budget)
-}
-
-func extractTarReader(
-	ctx context.Context,
-	reader *tar.Reader,
-	destination string,
-	budget *extractBudget,
-) ([]string, []Skip, error) {
-	var files []string
-	var skipped []Skip
-	for {
-		if err := ctx.Err(); err != nil {
-			return nil, nil, err
-		}
-		header, err := reader.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			return nil, nil, wrap(KindInvalid, "read tar header", err)
-		}
-		if err := budget.nextEntry(); err != nil {
-			return nil, nil, err
-		}
-		name, err := safeMemberName(header.Name, budget.limits.MaxDepth)
-		if err != nil {
-			return nil, nil, err
-		}
-		if name == "" {
-			continue
-		}
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := makeDirectory(destination, name); err != nil {
-				return nil, nil, err
-			}
-		case tar.TypeReg, tar.TypeRegA:
-			if header.Size < 0 || header.Size > budget.limits.MaxEntryBytes {
-				return nil, nil, wrap(KindLimit, "extract tar member", fmt.Errorf("%s exceeds the per-entry limit", name))
-			}
-			if err := extractRegularFile(ctx, reader, destination, name, budget); err != nil {
-				return nil, nil, err
-			}
-			files = append(files, name)
-		case tar.TypeSymlink:
-			skipped = append(skipped, Skip{Path: name, Reason: "symlink"})
-		case tar.TypeLink:
-			skipped = append(skipped, Skip{Path: name, Reason: "hard-link"})
-		default:
-			skipped = append(skipped, Skip{Path: name, Reason: "non-regular"})
-		}
-	}
-	return files, skipped, nil
 }
 
 func (b *extractBudget) nextEntry() error {
@@ -355,17 +249,6 @@ func destinationPath(root, name string) (string, error) {
 		return "", wrap(KindInvalid, "validate extraction target", fmt.Errorf("member escapes extraction root: %s", name))
 	}
 	return target, nil
-}
-
-func makeDirectory(root, name string) error {
-	target, err := destinationPath(root, name)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(target, 0o700); err != nil {
-		return wrap(KindExtract, "create archive directory", err)
-	}
-	return nil
 }
 
 func extractRegularFile(

--- a/internal/archive/extract_test.go
+++ b/internal/archive/extract_test.go
@@ -1,0 +1,248 @@
+package archive
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ulikunitz/xz"
+)
+
+type testEntry struct {
+	name     string
+	body     []byte
+	mode     os.FileMode
+	typeflag byte
+	linkname string
+}
+
+func TestExtractSupportedFormatsAndCommonRoot(t *testing.T) {
+	t.Parallel()
+	payload := []testEntry{{name: "wrapper/LICENSE", body: []byte("license")}}
+	innerTarGz := makeTar(t, []testEntry{{name: "LICENSE", body: []byte("gem license")}}, "gzip")
+	formats := map[string][]byte{
+		"zip":    makeZIP(t, payload),
+		"jar":    makeZIP(t, payload),
+		"tar":    makeTar(t, payload, "tar"),
+		"tar.gz": makeTar(t, payload, "gzip"),
+		"tar.xz": makeTar(t, payload, "xz"),
+		"gem": makeTar(t, []testEntry{
+			{name: "metadata.gz", body: []byte("metadata")},
+			{name: "data.tar.gz", body: innerTarGz},
+		}, "tar"),
+	}
+	for name, data := range formats {
+		t.Run(name, func(t *testing.T) {
+			archivePath := writeArchive(t, data)
+			result, err := Extract(context.Background(), archivePath, t.TempDir(), DefaultExtractLimits())
+			if err != nil {
+				t.Fatal(err)
+			}
+			contents, err := os.ReadFile(filepath.Join(result.Root, "LICENSE"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(contents) == 0 {
+				t.Fatal("LICENSE is empty")
+			}
+		})
+	}
+}
+
+func TestExtractDoesNotStripMixedRoots(t *testing.T) {
+	t.Parallel()
+	data := makeZIP(t, []testEntry{
+		{name: "wrapper/LICENSE", body: []byte("license")},
+		{name: "README", body: []byte("readme")},
+	})
+	result, err := Extract(context.Background(), writeArchive(t, data), t.TempDir(), DefaultExtractLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(result.Root, "wrapper", "LICENSE")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExtractRejectsTraversal(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"../escape", "/absolute", "..\\escape", "C:\\escape"} {
+		t.Run(name, func(t *testing.T) {
+			data := makeZIP(t, []testEntry{{name: name, body: []byte("bad")}})
+			_, err := Extract(context.Background(), writeArchive(t, data), t.TempDir(), DefaultExtractLimits())
+			if KindOf(err) != KindInvalid {
+				t.Fatalf("error = %v, kind = %q", err, KindOf(err))
+			}
+		})
+	}
+}
+
+func TestExtractRejectsTarTraversal(t *testing.T) {
+	t.Parallel()
+	data := makeTar(t, []testEntry{{name: "../escape", body: []byte("bad")}}, "tar")
+	_, err := Extract(context.Background(), writeArchive(t, data), t.TempDir(), DefaultExtractLimits())
+	if KindOf(err) != KindInvalid {
+		t.Fatalf("error = %v, kind = %q", err, KindOf(err))
+	}
+}
+
+func TestExtractLimits(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		entries []testEntry
+		limits  func(ExtractLimits) ExtractLimits
+	}{
+		{
+			name: "entry bytes", entries: []testEntry{{name: "large", body: []byte("12345")}},
+			limits: func(limits ExtractLimits) ExtractLimits { limits.MaxEntryBytes = 4; return limits },
+		},
+		{
+			name: "expanded bytes", entries: []testEntry{{name: "one", body: []byte("123")}, {name: "two", body: []byte("456")}},
+			limits: func(limits ExtractLimits) ExtractLimits {
+				limits.MaxEntryBytes = 5
+				limits.MaxExpandedBytes = 5
+				return limits
+			},
+		},
+		{
+			name: "entries", entries: []testEntry{{name: "one", body: []byte("1")}, {name: "two", body: []byte("2")}},
+			limits: func(limits ExtractLimits) ExtractLimits { limits.MaxEntries = 1; return limits },
+		},
+		{
+			name: "depth", entries: []testEntry{{name: "one/two/file", body: []byte("1")}},
+			limits: func(limits ExtractLimits) ExtractLimits { limits.MaxDepth = 2; return limits },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			limits := test.limits(DefaultExtractLimits())
+			_, err := Extract(context.Background(), writeArchive(t, makeZIP(t, test.entries)), t.TempDir(), limits)
+			if KindOf(err) != KindLimit {
+				t.Fatalf("error = %v, kind = %q", err, KindOf(err))
+			}
+		})
+	}
+}
+
+func TestExtractSkipsLinksAndSpecialEntries(t *testing.T) {
+	t.Parallel()
+	data := makeTar(t, []testEntry{
+		{name: "LICENSE", body: []byte("license")},
+		{name: "soft", typeflag: tar.TypeSymlink, linkname: "LICENSE"},
+		{name: "hard", typeflag: tar.TypeLink, linkname: "LICENSE"},
+		{name: "device", typeflag: tar.TypeChar},
+		{name: "socket", typeflag: tar.TypeFifo},
+	}, "tar")
+	result, err := Extract(context.Background(), writeArchive(t, data), t.TempDir(), DefaultExtractLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Skipped) != 4 {
+		t.Fatalf("skipped = %#v", result.Skipped)
+	}
+	for _, name := range []string{"soft", "hard", "device", "socket"} {
+		if _, err := os.Lstat(filepath.Join(result.Root, name)); !os.IsNotExist(err) {
+			t.Fatalf("special entry %q exists: %v", name, err)
+		}
+	}
+}
+
+func TestExtractUnsupported(t *testing.T) {
+	t.Parallel()
+	_, err := Extract(context.Background(), writeArchive(t, []byte("not an archive")), t.TempDir(), DefaultExtractLimits())
+	if KindOf(err) != KindUnsupported {
+		t.Fatalf("error = %v, kind = %q", err, KindOf(err))
+	}
+}
+
+func makeZIP(t *testing.T, entries []testEntry) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	for _, entry := range entries {
+		header := &zip.FileHeader{Name: entry.name, Method: zip.Deflate}
+		if entry.mode != 0 {
+			header.SetMode(entry.mode)
+		}
+		member, err := writer.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := member.Write(entry.body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func makeTar(t *testing.T, entries []testEntry, compression string) []byte {
+	t.Helper()
+	var output bytes.Buffer
+	var destination io.Writer = &output
+	var closeCompression func() error
+	switch compression {
+	case "gzip":
+		writer := gzip.NewWriter(&output)
+		destination = writer
+		closeCompression = writer.Close
+	case "xz":
+		writer, err := xz.NewWriter(&output)
+		if err != nil {
+			t.Fatal(err)
+		}
+		destination = writer
+		closeCompression = writer.Close
+	case "tar":
+		closeCompression = func() error { return nil }
+	default:
+		t.Fatalf("unknown compression %q", compression)
+	}
+	writer := tar.NewWriter(destination)
+	for _, entry := range entries {
+		typeflag := entry.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		header := &tar.Header{
+			Name: entry.name, Mode: 0o600, Size: int64(len(entry.body)),
+			Typeflag: typeflag, Linkname: entry.linkname,
+		}
+		if typeflag != tar.TypeReg && typeflag != tar.TypeRegA {
+			header.Size = 0
+		}
+		if err := writer.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if header.Size > 0 {
+			if _, err := writer.Write(entry.body); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := closeCompression(); err != nil {
+		t.Fatal(err)
+	}
+	return output.Bytes()
+}
+
+func writeArchive(t *testing.T, data []byte) string {
+	t.Helper()
+	filePath := filepath.Join(t.TempDir(), "archive")
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return filePath
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,0 +1,193 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/ecosyste-ms/licenses/internal/archive"
+	"github.com/ecosyste-ms/licenses/internal/scanner"
+)
+
+const successCacheDuration = 24 * time.Hour
+
+// ScanService is implemented by scanner.Scanner and kept narrow for handler
+// tests.
+type ScanService interface {
+	ScanURL(context.Context, string) (scanner.Report, error)
+}
+
+// Server exposes the synchronous v2 API and supporting pages.
+type Server struct {
+	service     ScanService
+	semaphore   chan struct{}
+	timeout     time.Duration
+	openAPIPath string
+	mux         *http.ServeMux
+}
+
+// New returns a fully configured HTTP handler.
+func New(service ScanService, maxConcurrent int, timeout time.Duration, openAPIPath string) (*Server, error) {
+	if service == nil {
+		return nil, errors.New("scan service is required")
+	}
+	if maxConcurrent <= 0 {
+		return nil, errors.New("maximum concurrency must be positive")
+	}
+	if timeout <= 0 {
+		return nil, errors.New("request timeout must be positive")
+	}
+	server := &Server{
+		service: service, semaphore: make(chan struct{}, maxConcurrent),
+		timeout: timeout, openAPIPath: openAPIPath, mux: http.NewServeMux(),
+	}
+	server.routes()
+	return server, nil
+}
+
+func (s *Server) routes() {
+	s.mux.HandleFunc("GET /api/v2/licenses", s.handleLicenses)
+	s.mux.HandleFunc("OPTIONS /api/v2/licenses", handleOptions)
+	s.mux.HandleFunc("GET /docs", redirectDocs)
+	s.mux.HandleFunc("GET /docs/", handleDocs)
+	s.mux.HandleFunc("GET /docs/api/v2/openapi.yaml", s.handleOpenAPI)
+	s.mux.HandleFunc("GET /healthz", handleHealth)
+	s.mux.HandleFunc("GET /", handleHome)
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	if len(r.URL.Path) >= len("/api/") && r.URL.Path[:len("/api/")] == "/api/" {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type")
+	}
+	s.mux.ServeHTTP(w, r)
+}
+
+func (s *Server) handleLicenses(w http.ResponseWriter, r *http.Request) {
+	rawURL := r.URL.Query().Get("url")
+	if rawURL == "" {
+		writeError(w, http.StatusBadRequest, "url parameter is required")
+		return
+	}
+	if len(rawURL) > 8<<10 {
+		writeError(w, http.StatusBadRequest, "url parameter is too long")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.timeout)
+	defer cancel()
+	select {
+	case s.semaphore <- struct{}{}:
+		defer func() { <-s.semaphore }()
+	case <-ctx.Done():
+		writeError(w, http.StatusGatewayTimeout, "scan timed out while waiting for capacity")
+		return
+	}
+
+	report, err := s.service.ScanURL(ctx, rawURL)
+	if err != nil {
+		status, message := responseError(err)
+		if status >= 500 {
+			slog.Error("v2 license scan failed", "error", err, "url", rawURL)
+		}
+		writeError(w, status, message)
+		return
+	}
+	w.Header().Set("Cache-Control", fmt.Sprintf(
+		"public, max-age=%d, s-maxage=%d", int(successCacheDuration.Seconds()), int(successCacheDuration.Seconds()),
+	))
+	w.Header().Set("ETag", fmt.Sprintf(`"%s-%s-%d"`, report.SHA256, report.Scanner.Version, report.Schema))
+	w.Header().Set("X-Archive-SHA256", report.SHA256)
+	writeJSON(w, http.StatusOK, report)
+}
+
+func responseError(err error) (int, string) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusGatewayTimeout, "scan timed out"
+	}
+	if errors.Is(err, context.Canceled) {
+		return http.StatusRequestTimeout, "scan canceled"
+	}
+	switch archive.KindOf(err) {
+	case archive.KindInvalid, archive.KindUnsupported:
+		return http.StatusBadRequest, err.Error()
+	case archive.KindLimit:
+		return http.StatusRequestEntityTooLarge, err.Error()
+	case archive.KindDownload:
+		return http.StatusBadGateway, "archive download failed"
+	case archive.KindExtract:
+		return http.StatusInternalServerError, "archive extraction failed"
+	default:
+		return http.StatusInternalServerError, "license scan failed"
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		slog.Error("encode JSON response", "error", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func handleOptions(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func handleHome(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(homeHTML))
+}
+
+func redirectDocs(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/docs/", http.StatusMovedPermanently)
+}
+
+func handleDocs(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(docsHTML))
+}
+
+func (s *Server) handleOpenAPI(w http.ResponseWriter, _ *http.Request) {
+	data, err := os.ReadFile(s.openAPIPath)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "OpenAPI specification not found")
+		return
+	}
+	w.Header().Set("Content-Type", "application/yaml; charset=utf-8")
+	_, _ = w.Write(data)
+}
+
+const homeHTML = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<title>Ecosyste.ms: Licenses v2</title><style>body{font:18px system-ui;max-width:52rem;margin:4rem auto;padding:0 1rem;line-height:1.55}code{background:#f3f3f3;padding:.15rem .3rem}</style></head>
+<body><h1>Ecosyste.ms: Licenses v2</h1><p>A bounded synchronous API for license evidence in package archives.</p>
+<p><code>GET /api/v2/licenses?url=https://example.test/package.tar.gz</code></p><p><a href="/docs/">API documentation</a></p></body></html>`
+
+const docsHTML = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Licenses v2 API documentation</title>
+<link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css"></head><body><div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script><script>SwaggerUIBundle({url:"/docs/api/v2/openapi.yaml",dom_id:"#swagger-ui",deepLinking:true,presets:[SwaggerUIBundle.presets.apis],layout:"BaseLayout"})</script></body></html>`

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -1,0 +1,233 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ecosyste-ms/licenses/internal/archive"
+	"github.com/ecosyste-ms/licenses/internal/scanner"
+)
+
+type fakeScanner struct {
+	report scanner.Report
+	err    error
+	call   func(context.Context)
+}
+
+func (f *fakeScanner) ScanURL(ctx context.Context, _ string) (scanner.Report, error) {
+	if f.call != nil {
+		f.call(ctx)
+	}
+	return f.report, f.err
+}
+
+func TestLicensesSuccess(t *testing.T) {
+	t.Parallel()
+	service := &fakeScanner{report: testReport()}
+	handler := newTestHandler(t, service, time.Second)
+	request := httptest.NewRequest(http.MethodGet, "/api/v2/licenses?url=https://example.test/package.zip", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if got := response.Header().Get("X-Archive-SHA256"); got != service.report.SHA256 {
+		t.Fatalf("X-Archive-SHA256 = %q", got)
+	}
+	if got := response.Header().Get("Cache-Control"); !strings.Contains(got, "public") {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	if got := response.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("CORS header = %q", got)
+	}
+	var decoded scanner.Report
+	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Schema != 1 || decoded.Files == nil || decoded.Errors == nil {
+		t.Fatalf("decoded report = %#v", decoded)
+	}
+}
+
+func TestLicensesValidationAndErrorMapping(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		path   string
+		err    error
+		status int
+	}{
+		{name: "missing URL", path: "/api/v2/licenses", status: http.StatusBadRequest},
+		{
+			name: "invalid", path: "/api/v2/licenses?url=bad",
+			err:    &archive.Error{Kind: archive.KindInvalid, Op: "validate", Err: errors.New("bad URL")},
+			status: http.StatusBadRequest,
+		},
+		{
+			name: "limit", path: "/api/v2/licenses?url=https://example.test/archive",
+			err:    &archive.Error{Kind: archive.KindLimit, Op: "extract", Err: errors.New("too large")},
+			status: http.StatusRequestEntityTooLarge,
+		},
+		{
+			name: "download", path: "/api/v2/licenses?url=https://example.test/archive",
+			err:    &archive.Error{Kind: archive.KindDownload, Op: "download", Err: errors.New("offline")},
+			status: http.StatusBadGateway,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := &fakeScanner{report: testReport(), err: test.err}
+			handler := newTestHandler(t, service, time.Second)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, test.path, nil))
+			if response.Code != test.status {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, test.status, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestLicensesSemaphoreTimeout(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var calls atomic.Int32
+	service := &fakeScanner{report: testReport(), call: func(ctx context.Context) {
+		calls.Add(1)
+		entered <- struct{}{}
+		<-release
+	}}
+	openAPIPath := writeSpec(t)
+	handler, err := New(service, 1, 30*time.Millisecond, openAPIPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/v2/licenses?url=https://example.test/one", nil))
+	}()
+	<-entered
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/v2/licenses?url=https://example.test/two", nil))
+	if response.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("scanner calls = %d, want 1", calls.Load())
+	}
+	close(release)
+	<-firstDone
+}
+
+func TestSupportingRoutes(t *testing.T) {
+	t.Parallel()
+	handler := newTestHandler(t, &fakeScanner{report: testReport()}, time.Second)
+	tests := []struct {
+		path        string
+		status      int
+		contentType string
+	}{
+		{path: "/", status: 200, contentType: "text/html"},
+		{path: "/healthz", status: 200, contentType: "application/json"},
+		{path: "/docs/", status: 200, contentType: "text/html"},
+		{path: "/docs/api/v2/openapi.yaml", status: 200, contentType: "application/yaml"},
+		{path: "/missing", status: 404, contentType: "application/json"},
+	}
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, test.path, nil))
+			if response.Code != test.status {
+				t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+			}
+			if got := response.Header().Get("Content-Type"); !strings.Contains(got, test.contentType) {
+				t.Fatalf("Content-Type = %q", got)
+			}
+		})
+	}
+}
+
+func TestUnsupportedMethod(t *testing.T) {
+	t.Parallel()
+	handler := newTestHandler(t, &fakeScanner{report: testReport()}, time.Second)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/api/v2/licenses", nil))
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d", response.Code)
+	}
+}
+
+func TestOptions(t *testing.T) {
+	t.Parallel()
+	handler := newTestHandler(t, &fakeScanner{report: testReport()}, time.Second)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodOptions, "/api/v2/licenses", nil))
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d", response.Code)
+	}
+	if got := response.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, "GET") {
+		t.Fatalf("Access-Control-Allow-Methods = %q", got)
+	}
+}
+
+func BenchmarkHandleLicenses(b *testing.B) {
+	handler, err := New(&fakeScanner{report: testReport()}, 4, time.Second, "unused")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/api/v2/licenses?url=https://example.test/package.zip", nil)
+			handler.ServeHTTP(response, request)
+			if response.Code != http.StatusOK {
+				b.Fatalf("status = %d", response.Code)
+			}
+		}
+	})
+}
+
+func newTestHandler(t *testing.T, service ScanService, timeout time.Duration) *Server {
+	t.Helper()
+	handler, err := New(service, 2, timeout, writeSpec(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handler
+}
+
+func writeSpec(t *testing.T) string {
+	t.Helper()
+	filePath := filepath.Join(t.TempDir(), "openapi.yaml")
+	if err := os.WriteFile(filePath, []byte("openapi: 3.0.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return filePath
+}
+
+func testReport() scanner.Report {
+	return scanner.Report{
+		Schema: 1, URL: "https://example.test/package.zip",
+		SHA256: strings.Repeat("a", 64),
+		Scanner: scanner.ScannerInfo{
+			Name: scanner.ScannerName, Version: scanner.ScannerVersion,
+			Corpus: scanner.CorpusInfo{Version: "test", SourceCommit: strings.Repeat("b", 40), RuleCount: 1},
+		},
+		Summary: scanner.Summary{
+			Complete: true, RootExpressions: []scanner.Expression{}, OtherExpressions: []scanner.Expression{},
+		},
+		Declared: []scanner.DeclaredLicense{}, Files: []scanner.File{},
+		AttributionFiles: []scanner.AttributionFile{}, Skipped: []scanner.Skip{}, Errors: []scanner.ScanError{},
+	}
+}

--- a/internal/scanner/model.go
+++ b/internal/scanner/model.go
@@ -1,0 +1,100 @@
+package scanner
+
+import licenses "github.com/git-pkgs/licenses"
+
+const (
+	ReportSchemaVersion = 1
+	ScannerName         = "git-pkgs/licenses"
+	ScannerVersion      = "0.2.0"
+)
+
+// Report is the v2 response contract.
+type Report struct {
+	Schema           int               `json:"schema"`
+	URL              string            `json:"url"`
+	SHA256           string            `json:"sha256"`
+	Scanner          ScannerInfo       `json:"scanner"`
+	Summary          Summary           `json:"summary"`
+	Declared         []DeclaredLicense `json:"declared"`
+	Files            []File            `json:"files"`
+	AttributionFiles []AttributionFile `json:"attribution_files"`
+	Skipped          []Skip            `json:"skipped"`
+	Errors           []ScanError       `json:"errors"`
+}
+
+type ScannerInfo struct {
+	Name    string     `json:"name"`
+	Version string     `json:"version"`
+	Corpus  CorpusInfo `json:"corpus"`
+}
+
+type CorpusInfo struct {
+	Version      string `json:"version"`
+	SourceCommit string `json:"source_commit"`
+	RuleCount    int    `json:"rule_count"`
+}
+
+type Summary struct {
+	Complete         bool         `json:"complete"`
+	FilesVisited     int          `json:"files_visited"`
+	FilesScanned     int          `json:"files_scanned"`
+	BytesScanned     int64        `json:"bytes_scanned"`
+	RootExpressions  []Expression `json:"root_expressions"`
+	OtherExpressions []Expression `json:"other_expressions"`
+}
+
+type Expression struct {
+	Expression     string                  `json:"expression"`
+	Identification licenses.Identification `json:"identification"`
+}
+
+type DeclaredLicense struct {
+	Path                 string `json:"path"`
+	Raw                  string `json:"raw"`
+	NormalizedExpression string `json:"normalized_expression,omitempty"`
+}
+
+type File struct {
+	Path                string      `json:"path"`
+	Size                int64       `json:"size"`
+	SHA256              string      `json:"sha256"`
+	Encoding            string      `json:"encoding"`
+	LicenseTextCoverage float64     `json:"license_text_coverage"`
+	Detections          []Detection `json:"detections"`
+	Clues               []Match     `json:"clues"`
+}
+
+type Detection struct {
+	Expression     string                  `json:"expression"`
+	Identification licenses.Identification `json:"identification"`
+	Matches        []Match                 `json:"matches"`
+}
+
+type Match struct {
+	RuleID     string          `json:"rule_id"`
+	LicenseIDs []string        `json:"license_ids"`
+	Kind       licenses.Kind   `json:"kind"`
+	Method     licenses.Method `json:"method"`
+	Score      float64         `json:"score"`
+	Coverage   float64         `json:"coverage"`
+	Start      int             `json:"start"`
+	End        int             `json:"end"`
+}
+
+type AttributionFile struct {
+	Path     string   `json:"path"`
+	Roles    []string `json:"roles"`
+	SHA256   string   `json:"sha256"`
+	Encoding string   `json:"encoding"`
+	Content  string   `json:"content"`
+}
+
+type Skip struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+type ScanError struct {
+	Path  string `json:"path"`
+	Error string `json:"error"`
+}

--- a/internal/scanner/policy.go
+++ b/internal/scanner/policy.go
@@ -1,0 +1,169 @@
+package scanner
+
+import (
+	"bytes"
+	pathpkg "path"
+	"strings"
+
+	licenses "github.com/git-pkgs/licenses"
+)
+
+const minimumMarkerLength = 2
+
+func applyScanPolicy(filePath string, input []byte, result *licenses.Result) {
+	if isLegalFile(filePath) {
+		return
+	}
+	documentMarkers := usesDocumentMarkers(filePath)
+	detections := result.Detections[:0]
+	for _, detection := range result.Detections {
+		matches := detection.Matches[:0]
+		for _, match := range detection.Matches {
+			if match.Kind == licenses.KindReference && crossesBlockBoundary(
+				input, match.Start, match.End, documentMarkers,
+			) {
+				result.Clues = append(result.Clues, match)
+				continue
+			}
+			matches = append(matches, match)
+		}
+		if len(matches) > 0 {
+			detection.Matches = matches
+			detections = append(detections, detection)
+		}
+	}
+	result.Detections = detections
+}
+
+func crossesBlockBoundary(input []byte, start, end int, documentMarkers bool) bool {
+	if start < 0 || start >= end || end > len(input) {
+		return false
+	}
+	for searchStart := start; searchStart < end; {
+		relative := bytes.IndexByte(input[searchStart:end], '\n')
+		if relative < 0 {
+			return false
+		}
+		newline := searchStart + relative
+		leftStart := bytes.LastIndexByte(input[:newline], '\n') + 1
+		rightEnd := len(input)
+		if next := bytes.IndexByte(input[newline+1:], '\n'); next >= 0 {
+			rightEnd = newline + 1 + next
+		}
+		left := bytes.TrimSpace(input[leftStart:newline])
+		right := bytes.TrimSpace(input[newline+1 : rightEnd])
+		paragraphLeft, paragraphRight := stripCommonCommentLeader(left, right)
+		if len(paragraphLeft) == 0 || len(paragraphRight) == 0 {
+			return true
+		}
+		if documentMarkers && isDocumentBoundary(left, right) {
+			return true
+		}
+		searchStart = newline + 1
+	}
+	return false
+}
+
+func stripCommonCommentLeader(left, right []byte) ([]byte, []byte) {
+	for _, leader := range [][]byte{[]byte("//"), []byte("--"), []byte("#"), []byte("*"), []byte(";"), []byte("%")} {
+		strippedLeft, leftHasLeader := stripCommentLeader(left, leader)
+		strippedRight, rightHasLeader := stripCommentLeader(right, leader)
+		if leftHasLeader && rightHasLeader {
+			return strippedLeft, strippedRight
+		}
+	}
+	return left, right
+}
+
+func stripCommentLeader(line, leader []byte) ([]byte, bool) {
+	if !bytes.HasPrefix(line, leader) {
+		return line, false
+	}
+	for bytes.HasPrefix(line, leader) {
+		line = line[len(leader):]
+	}
+	return bytes.TrimSpace(line), true
+}
+
+func usesDocumentMarkers(filePath string) bool {
+	switch strings.ToLower(pathpkg.Ext(filepathSlash(filePath))) {
+	case ".md", ".markdown", ".mdown", ".mdx", ".mkd":
+		return true
+	}
+	return strings.EqualFold(pathpkg.Base(filepathSlash(filePath)), "readme")
+}
+
+func isDocumentBoundary(left, right []byte) bool {
+	return isHeadingLine(left) || isHeadingLine(right) || isTableLine(left) ||
+		isTableLine(right) || isListItem(right)
+}
+
+func isHeadingLine(line []byte) bool { return line[0] == '#' || line[0] == '=' }
+
+func isTableLine(line []byte) bool { return line[0] == '|' || line[len(line)-1] == '|' }
+
+func isListItem(line []byte) bool {
+	if len(line) < minimumMarkerLength {
+		return false
+	}
+	switch line[0] {
+	case '-', '*', '+', '>':
+		return line[1] == ' ' || line[1] == '\t'
+	}
+	index := 0
+	for index < len(line) && line[index] >= '0' && line[index] <= '9' {
+		index++
+	}
+	if index == 0 || index+1 >= len(line) || (line[index] != '.' && line[index] != ')') {
+		return false
+	}
+	return line[index+1] == ' ' || line[index+1] == '\t'
+}
+
+func isLegalFile(filePath string) bool {
+	cleaned := filepathSlash(filePath)
+	parts := strings.Split(cleaned, "/")
+	for _, directory := range parts[:len(parts)-1] {
+		switch strings.ToLower(directory) {
+		case "license", "licenses", "licence", "licences":
+			return true
+		}
+	}
+	name := strings.ToLower(pathpkg.Base(cleaned))
+	for _, prefix := range []string{
+		"licenses", "license", "licences", "licence", "copying", "mit-license",
+		"notices", "notice", "copyright", "unlicense",
+	} {
+		if hasLegalNamePrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isNoticeFile(filePath string) bool {
+	name := strings.ToLower(pathpkg.Base(filepathSlash(filePath)))
+	return hasLegalNamePrefix(name, "notice") || hasLegalNamePrefix(name, "notices")
+}
+
+func isReadmeFile(filePath string) bool {
+	name := strings.ToLower(pathpkg.Base(filepathSlash(filePath)))
+	return name == "readme" || strings.HasPrefix(name, "readme.")
+}
+
+func hasLegalNamePrefix(name, prefix string) bool {
+	if name == prefix {
+		return true
+	}
+	if !strings.HasPrefix(name, prefix) || len(name) == len(prefix) {
+		return false
+	}
+	switch name[len(prefix)] {
+	case '.', '-', '_':
+		return true
+	default:
+		return false
+	}
+}
+
+func filepathSlash(value string) string { return strings.ReplaceAll(value, "\\", "/") }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	licenses "github.com/git-pkgs/licenses"
+	"github.com/git-pkgs/magic"
 
 	archivepkg "github.com/ecosyste-ms/licenses/internal/archive"
 )
@@ -413,10 +414,11 @@ func scanFile(ctx context.Context, matcher *licenses.Matcher, task fileTask, max
 	if tooLarge {
 		return fileOutcome{task: task, tooLarge: true}
 	}
-	if isBinary(data) {
+	detection := magic.Detect(data)
+	if detection.Kind == magic.KindBinary {
 		return fileOutcome{task: task, binary: true}
 	}
-	decoded := decodeText(data)
+	decoded := decodeText(data, detection)
 	result, err := matcher.Match(ctx, decoded.data)
 	if err != nil {
 		return fileOutcome{task: task, bytes: int64(len(data)), scanned: true, err: err}
@@ -633,7 +635,7 @@ func populateAttribution(report *Report, candidates []attributionCandidate, limi
 			report.Errors = append(report.Errors, ScanError{Path: candidate.display, Error: "read attribution file"})
 			continue
 		}
-		decoded := decodeText(data)
+		decoded := decodeText(data, magic.Detect(data))
 		report.AttributionFiles = append(report.AttributionFiles, AttributionFile{
 			Path: candidate.display, Roles: slices.Clone(candidate.roles), SHA256: candidate.sha256,
 			Encoding: candidate.encoding, Content: string(decoded.data),

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,0 +1,662 @@
+package scanner
+
+import (
+	"cmp"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+
+	licenses "github.com/git-pkgs/licenses"
+
+	archivepkg "github.com/ecosyste-ms/licenses/internal/archive"
+)
+
+const maxScannerWorkers = 16
+
+var defaultSkippedDirectories = map[string]bool{
+	"vendor":       true,
+	"node_modules": true,
+	"__pycache__":  true,
+	".bundle":      true,
+	".venv":        true,
+	"venv":         true,
+	"target":       true,
+	"build":        true,
+	"dist":         true,
+	"out":          true,
+	"_build":       true,
+	"deps":         true,
+	"Pods":         true,
+	"third_party":  true,
+	"thirdparty":   true,
+	"external":     true,
+	"testdata":     true,
+	"tmp":          true,
+	"temp":         true,
+	"cache":        true,
+	"coverage":     true,
+}
+
+// Limits bounds the text scan and attribution response.
+type Limits struct {
+	MaxDepth            int
+	MaxFiles            int
+	MaxFileBytes        int64
+	Workers             int
+	MaxAttributionFiles int
+	MaxAttributionBytes int64
+}
+
+// DefaultLimits returns the same project-scan limits as the scanner CLI plus
+// explicit bounds for returned attribution text.
+func DefaultLimits() Limits {
+	return Limits{
+		MaxDepth:            32,
+		MaxFiles:            10_000,
+		MaxFileBytes:        1 << 20,
+		Workers:             min(runtime.GOMAXPROCS(0), maxScannerWorkers),
+		MaxAttributionFiles: 64,
+		MaxAttributionBytes: 4 << 20,
+	}
+}
+
+// Scanner downloads, extracts, and scans package archives.
+type Scanner struct {
+	Matcher       *licenses.Matcher
+	ArchiveClient *archivepkg.Client
+	ExtractLimits archivepkg.ExtractLimits
+	Limits        Limits
+}
+
+// New initializes the embedded matcher once and returns a production scanner.
+func New() (*Scanner, error) {
+	matcher, err := licenses.New()
+	if err != nil {
+		return nil, fmt.Errorf("initialize license matcher: %w", err)
+	}
+	downloadLimits := archivepkg.DefaultDownloadLimits()
+	return &Scanner{
+		Matcher:       matcher,
+		ArchiveClient: archivepkg.NewClient(downloadLimits),
+		ExtractLimits: archivepkg.DefaultExtractLimits(),
+		Limits:        DefaultLimits(),
+	}, nil
+}
+
+// ScanURL performs a bounded synchronous scan of rawURL.
+func (s *Scanner) ScanURL(ctx context.Context, rawURL string) (Report, error) {
+	if err := s.validate(); err != nil {
+		return Report{}, err
+	}
+	temporary, err := os.MkdirTemp("", "licenses-v2-*")
+	if err != nil {
+		return Report{}, fmt.Errorf("create scan workspace: %w", err)
+	}
+	defer os.RemoveAll(temporary)
+
+	archivePath := filepath.Join(temporary, "archive")
+	digest, err := s.ArchiveClient.Download(ctx, rawURL, archivePath)
+	if err != nil {
+		return Report{}, err
+	}
+	extracted, err := archivepkg.Extract(ctx, archivePath, filepath.Join(temporary, "extracted"), s.ExtractLimits)
+	if err != nil {
+		return Report{}, err
+	}
+	report, err := s.ScanDirectory(ctx, rawURL, digest, extracted.Root)
+	if err != nil {
+		return Report{}, err
+	}
+	for _, skipped := range extracted.Skipped {
+		report.Skipped = append(report.Skipped, Skip{Path: skipped.Path, Reason: skipped.Reason})
+	}
+	sortReport(&report)
+	return report, nil
+}
+
+func (s *Scanner) validate() error {
+	if s == nil || s.Matcher == nil {
+		return errors.New("license matcher is not configured")
+	}
+	if s.ArchiveClient == nil {
+		return errors.New("archive client is not configured")
+	}
+	limits := s.Limits
+	if limits.MaxDepth <= 0 || limits.MaxFiles <= 0 || limits.MaxFileBytes <= 0 ||
+		limits.Workers <= 0 || limits.MaxAttributionFiles <= 0 || limits.MaxAttributionBytes <= 0 {
+		return errors.New("all scanner limits must be positive")
+	}
+	return nil
+}
+
+// ScanDirectory scans an already extracted root. It is exported to support
+// fixture comparison and downstream integration tests without networking.
+func (s *Scanner) ScanDirectory(ctx context.Context, rawURL, archiveSHA, root string) (Report, error) {
+	if err := s.validate(); err != nil {
+		return Report{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return Report{}, err
+	}
+	corpus := s.Matcher.Corpus()
+	report := Report{
+		Schema: ReportSchemaVersion,
+		URL:    rawURL,
+		SHA256: archiveSHA,
+		Scanner: ScannerInfo{
+			Name:    ScannerName,
+			Version: ScannerVersion,
+			Corpus: CorpusInfo{
+				Version:      corpus.Version,
+				SourceCommit: corpus.SourceCommit,
+				RuleCount:    corpus.RuleCount,
+			},
+		},
+		Summary: Summary{
+			Complete:         true,
+			RootExpressions:  make([]Expression, 0),
+			OtherExpressions: make([]Expression, 0),
+		},
+		Declared:         make([]DeclaredLicense, 0),
+		Files:            make([]File, 0),
+		AttributionFiles: make([]AttributionFile, 0),
+		Skipped:          make([]Skip, 0),
+		Errors:           make([]ScanError, 0),
+	}
+
+	tasks, discoverySkipped, discoveryErrors, truncated, err := discoverFiles(ctx, root, s.Limits, &report.Summary)
+	if err != nil {
+		return Report{}, err
+	}
+	report.Skipped = append(report.Skipped, discoverySkipped...)
+	report.Errors = append(report.Errors, discoveryErrors...)
+	if len(discoveryErrors) > 0 {
+		report.Summary.Complete = false
+	}
+	if truncated {
+		report.Summary.Complete = false
+	}
+
+	outcomes := scanFiles(ctx, s.Matcher, tasks, s.Limits)
+	rootExpressions := make(map[string]Expression)
+	otherExpressions := make(map[string]Expression)
+	var attribution []attributionCandidate
+	for outcome := range outcomes {
+		if outcome.scanned {
+			report.Summary.FilesScanned++
+			report.Summary.BytesScanned += outcome.bytes
+		}
+		switch {
+		case outcome.err != nil:
+			report.Summary.Complete = false
+			report.Errors = append(report.Errors, ScanError{Path: outcome.task.display, Error: safeErrorMessage(outcome.err)})
+		case outcome.binary:
+			report.Skipped = append(report.Skipped, Skip{Path: outcome.task.display, Reason: "binary"})
+		case outcome.tooLarge:
+			report.Skipped = append(report.Skipped, Skip{Path: outcome.task.display, Reason: "size"})
+		case outcome.file != nil:
+			report.Files = append(report.Files, *outcome.file)
+			addExpressions(outcome.task.display, outcome.file.Detections, rootExpressions, otherExpressions)
+		}
+		if outcome.attribution != nil {
+			attribution = append(attribution, *outcome.attribution)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return Report{}, err
+	}
+
+	report.Summary.RootExpressions = expressionValues(rootExpressions)
+	report.Summary.OtherExpressions = expressionValues(otherExpressions)
+	populateAttribution(&report, attribution, s.Limits)
+	sortReport(&report)
+	return report, nil
+}
+
+type fileTask struct {
+	path    string
+	display string
+}
+
+type fileOutcome struct {
+	task        fileTask
+	file        *File
+	attribution *attributionCandidate
+	bytes       int64
+	scanned     bool
+	binary      bool
+	tooLarge    bool
+	err         error
+}
+
+type attributionCandidate struct {
+	path     string
+	display  string
+	roles    []string
+	sha256   string
+	encoding string
+	size     int64
+}
+
+func discoverFiles(
+	ctx context.Context,
+	root string,
+	limits Limits,
+	summary *Summary,
+) ([]fileTask, []Skip, []ScanError, bool, error) {
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, nil, nil, false, fmt.Errorf("resolve scan root: %w", err)
+	}
+	var tasks []fileTask
+	var skipped []Skip
+	var scanErrors []ScanError
+	truncated := false
+	err = filepath.WalkDir(resolved, func(filePath string, entry fs.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		relative, relErr := filepath.Rel(resolved, filePath)
+		if relErr != nil {
+			return relErr
+		}
+		display := filepath.ToSlash(relative)
+		if walkErr != nil {
+			if display == "." {
+				return walkErr
+			}
+			scanErrors = append(scanErrors, ScanError{Path: display, Error: safeErrorMessage(walkErr)})
+			if entry != nil && entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			if display == "." {
+				return nil
+			}
+			if reason := skippedDirectoryReason(entry.Name()); reason != "" {
+				skipped = append(skipped, Skip{Path: display, Reason: reason})
+				return filepath.SkipDir
+			}
+			if pathDepth(display) > limits.MaxDepth {
+				skipped = append(skipped, Skip{Path: display, Reason: "depth"})
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if summary.FilesVisited >= limits.MaxFiles {
+			truncated = true
+			skipped = append(skipped, Skip{Path: display, Reason: "file-limit"})
+			return fs.SkipAll
+		}
+		summary.FilesVisited++
+		if entry.Type()&os.ModeSymlink != 0 {
+			skipped = append(skipped, Skip{Path: display, Reason: "symlink"})
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			scanErrors = append(scanErrors, ScanError{Path: display, Error: safeErrorMessage(err)})
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			skipped = append(skipped, Skip{Path: display, Reason: "non-regular"})
+			return nil
+		}
+		if pathDepth(display) > limits.MaxDepth {
+			skipped = append(skipped, Skip{Path: display, Reason: "depth"})
+			return nil
+		}
+		if info.Size() > limits.MaxFileBytes {
+			skipped = append(skipped, Skip{Path: display, Reason: "size"})
+			return nil
+		}
+		tasks = append(tasks, fileTask{path: filePath, display: display})
+		return nil
+	})
+	if err != nil {
+		return nil, nil, nil, false, fmt.Errorf("discover files: %w", err)
+	}
+	return tasks, skipped, scanErrors, truncated, nil
+}
+
+func safeErrorMessage(err error) string {
+	var pathError *os.PathError
+	if errors.As(err, &pathError) {
+		return pathError.Err.Error()
+	}
+	return err.Error()
+}
+
+func skippedDirectoryReason(name string) string {
+	if name == ".git" {
+		return "version-control"
+	}
+	if strings.HasPrefix(name, ".") {
+		return "hidden-directory"
+	}
+	if defaultSkippedDirectories[name] {
+		return "project-scope"
+	}
+	return ""
+}
+
+func pathDepth(filePath string) int {
+	if filePath == "" || filePath == "." {
+		return 0
+	}
+	return strings.Count(filepath.ToSlash(filepath.Clean(filePath)), "/") + 1
+}
+
+func scanFiles(
+	ctx context.Context,
+	matcher *licenses.Matcher,
+	tasks []fileTask,
+	limits Limits,
+) <-chan fileOutcome {
+	outcomes := make(chan fileOutcome)
+	if len(tasks) == 0 {
+		close(outcomes)
+		return outcomes
+	}
+	jobs := make(chan fileTask)
+	workerCount := min(limits.Workers, maxScannerWorkers, len(tasks))
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for task := range jobs {
+				outcome := scanFile(ctx, matcher, task, limits.MaxFileBytes)
+				select {
+				case outcomes <- outcome:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, task := range tasks {
+			select {
+			case jobs <- task:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	go func() {
+		workers.Wait()
+		close(outcomes)
+	}()
+	return outcomes
+}
+
+func scanFile(ctx context.Context, matcher *licenses.Matcher, task fileTask, maxBytes int64) fileOutcome {
+	data, tooLarge, err := readFile(task.path, maxBytes)
+	if err != nil {
+		return fileOutcome{task: task, err: err}
+	}
+	if tooLarge {
+		return fileOutcome{task: task, tooLarge: true}
+	}
+	if isBinary(data) {
+		return fileOutcome{task: task, binary: true}
+	}
+	decoded := decodeText(data)
+	result, err := matcher.Match(ctx, decoded.data)
+	if err != nil {
+		return fileOutcome{task: task, bytes: int64(len(data)), scanned: true, err: err}
+	}
+	applyScanPolicy(task.display, decoded.data, &result)
+	coverage := licenseTextCoverage(result, len(decoded.data))
+	roles := attributionRoles(task.display, result)
+	remapResultOffsets(&result, decoded)
+	digest := sha256.Sum256(data)
+	fileDigest := hex.EncodeToString(digest[:])
+	outcome := fileOutcome{task: task, bytes: int64(len(data)), scanned: true}
+	if len(result.Detections) > 0 || len(result.Clues) > 0 {
+		file := makeFile(task.display, int64(len(data)), fileDigest, decoded.encoding, coverage, result)
+		outcome.file = &file
+	}
+	if len(roles) > 0 {
+		outcome.attribution = &attributionCandidate{
+			path: task.path, display: task.display, roles: roles, sha256: fileDigest,
+			encoding: decoded.encoding, size: int64(len(data)),
+		}
+	}
+	return outcome
+}
+
+func readFile(filePath string, maximum int64) ([]byte, bool, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, false, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(data)) > maximum {
+		return nil, true, nil
+	}
+	return data, false, nil
+}
+
+func makeFile(
+	filePath string,
+	size int64,
+	digest string,
+	encoding string,
+	coverage float64,
+	result licenses.Result,
+) File {
+	file := File{
+		Path: filePath, Size: size, SHA256: digest, Encoding: encoding,
+		LicenseTextCoverage: coverage, Detections: make([]Detection, 0, len(result.Detections)),
+		Clues: make([]Match, 0, len(result.Clues)),
+	}
+	for _, detection := range result.Detections {
+		record := Detection{
+			Expression: detection.Expression, Identification: detection.Identification,
+			Matches: make([]Match, 0, len(detection.Matches)),
+		}
+		for _, match := range detection.Matches {
+			record.Matches = append(record.Matches, makeMatch(match))
+		}
+		file.Detections = append(file.Detections, record)
+	}
+	for _, clue := range result.Clues {
+		file.Clues = append(file.Clues, makeMatch(clue))
+	}
+	sortFile(&file)
+	return file
+}
+
+func sortFile(file *File) {
+	for index := range file.Detections {
+		slices.SortFunc(file.Detections[index].Matches, compareMatches)
+	}
+	slices.SortFunc(file.Clues, compareMatches)
+	slices.SortFunc(file.Detections, func(a, b Detection) int {
+		if compared := compareMatches(a.Matches[0], b.Matches[0]); compared != 0 {
+			return compared
+		}
+		return strings.Compare(a.Expression, b.Expression)
+	})
+}
+
+func compareMatches(a, b Match) int {
+	if compared := cmp.Compare(a.Start, b.Start); compared != 0 {
+		return compared
+	}
+	if compared := cmp.Compare(a.End, b.End); compared != 0 {
+		return compared
+	}
+	if compared := strings.Compare(a.RuleID, b.RuleID); compared != 0 {
+		return compared
+	}
+	return strings.Compare(string(a.Method), string(b.Method))
+}
+
+func makeMatch(match licenses.Match) Match {
+	ids := slices.Clone(match.LicenseIDs)
+	if ids == nil {
+		ids = make([]string, 0)
+	}
+	return Match{
+		RuleID: match.RuleID, LicenseIDs: ids, Kind: match.Kind, Method: match.Method,
+		Score: match.Score, Coverage: match.Coverage, Start: match.Start, End: match.End,
+	}
+}
+
+type byteRange struct{ start, end int }
+
+func licenseTextCoverage(result licenses.Result, length int) float64 {
+	if length == 0 {
+		return 0
+	}
+	var ranges []byteRange
+	for _, detection := range result.Detections {
+		for _, match := range detection.Matches {
+			if match.Kind == licenses.KindText || match.Kind == licenses.KindNotice {
+				ranges = append(ranges, byteRange{start: max(0, match.Start), end: min(length, match.End)})
+			}
+		}
+	}
+	if len(ranges) == 0 {
+		return 0
+	}
+	slices.SortFunc(ranges, func(a, b byteRange) int {
+		if compared := cmp.Compare(a.start, b.start); compared != 0 {
+			return compared
+		}
+		return cmp.Compare(a.end, b.end)
+	})
+	covered := 0
+	current := ranges[0]
+	for _, candidate := range ranges[1:] {
+		if candidate.start <= current.end {
+			current.end = max(current.end, candidate.end)
+			continue
+		}
+		covered += max(0, current.end-current.start)
+		current = candidate
+	}
+	covered += max(0, current.end-current.start)
+	return math.Round((float64(covered)/float64(length)*100)*100) / 100
+}
+
+func attributionRoles(filePath string, result licenses.Result) []string {
+	licenseRole := isLegalFile(filePath) && !isNoticeFile(filePath)
+	noticeRole := isNoticeFile(filePath)
+	for _, detection := range result.Detections {
+		for _, match := range detection.Matches {
+			switch match.Kind {
+			case licenses.KindText:
+				licenseRole = true
+			case licenses.KindNotice:
+				noticeRole = true
+			}
+		}
+	}
+	roles := make([]string, 0, 2)
+	if licenseRole {
+		roles = append(roles, "license")
+	}
+	if noticeRole {
+		roles = append(roles, "notice")
+	}
+	return roles
+}
+
+func addExpressions(
+	filePath string,
+	detections []Detection,
+	rootExpressions map[string]Expression,
+	otherExpressions map[string]Expression,
+) {
+	destination := otherExpressions
+	if !strings.Contains(filepathSlash(filePath), "/") && (isLegalFile(filePath) || isReadmeFile(filePath)) {
+		destination = rootExpressions
+	}
+	for _, detection := range detections {
+		key := detection.Expression + "\x00" + string(detection.Identification)
+		destination[key] = Expression{
+			Expression: detection.Expression, Identification: detection.Identification,
+		}
+	}
+}
+
+func expressionValues(values map[string]Expression) []Expression {
+	result := make([]Expression, 0, len(values))
+	for _, expression := range values {
+		result = append(result, expression)
+	}
+	slices.SortFunc(result, func(a, b Expression) int {
+		if compared := strings.Compare(a.Expression, b.Expression); compared != 0 {
+			return compared
+		}
+		return strings.Compare(string(a.Identification), string(b.Identification))
+	})
+	return result
+}
+
+func populateAttribution(report *Report, candidates []attributionCandidate, limits Limits) {
+	slices.SortFunc(candidates, func(a, b attributionCandidate) int {
+		return strings.Compare(a.display, b.display)
+	})
+	var total int64
+	for _, candidate := range candidates {
+		if len(report.AttributionFiles) >= limits.MaxAttributionFiles ||
+			candidate.size > limits.MaxAttributionBytes-total {
+			report.Skipped = append(report.Skipped, Skip{Path: candidate.display, Reason: "attribution-limit"})
+			continue
+		}
+		data, err := os.ReadFile(candidate.path)
+		if err != nil {
+			report.Summary.Complete = false
+			report.Errors = append(report.Errors, ScanError{Path: candidate.display, Error: "read attribution file"})
+			continue
+		}
+		decoded := decodeText(data)
+		report.AttributionFiles = append(report.AttributionFiles, AttributionFile{
+			Path: candidate.display, Roles: slices.Clone(candidate.roles), SHA256: candidate.sha256,
+			Encoding: candidate.encoding, Content: string(decoded.data),
+		})
+		total += int64(len(data))
+	}
+}
+
+func sortReport(report *Report) {
+	slices.SortFunc(report.Files, func(a, b File) int { return strings.Compare(a.Path, b.Path) })
+	slices.SortFunc(report.AttributionFiles, func(a, b AttributionFile) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+	slices.SortFunc(report.Skipped, func(a, b Skip) int {
+		if compared := strings.Compare(a.Path, b.Path); compared != 0 {
+			return compared
+		}
+		return strings.Compare(a.Reason, b.Reason)
+	})
+	slices.SortFunc(report.Errors, func(a, b ScanError) int {
+		if compared := strings.Compare(a.Path, b.Path); compared != 0 {
+			return compared
+		}
+		return strings.Compare(a.Error, b.Error)
+	})
+}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,0 +1,474 @@
+package scanner
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+	"unicode/utf16"
+
+	licenses "github.com/git-pkgs/licenses"
+
+	archivepkg "github.com/ecosyste-ms/licenses/internal/archive"
+)
+
+const mitLicense = `MIT License
+
+Copyright (c) 2026 Ecosyste.ms
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`
+
+func TestScanDirectoryEvidenceAndAttribution(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "LICENSE", []byte(mitLicense))
+	writeTestFile(t, root, "NOTICE", []byte("Project notice\nSPDX-License-Identifier: MIT\n"))
+	writeTestFile(t, root, "nested/LICENSE", []byte("SPDX-License-Identifier: Apache-2.0\n"))
+	writeTestFile(t, root, "src/partial.go", []byte("// SPDX-License-Identifier: MIT AND LicenseRef-local\n"))
+	writeTestFile(t, root, "src/unknown.go", []byte("// SPDX-License-Identifier: LicenseRef-local\n"))
+	writeTestFile(t, root, "src/binary", []byte{0, 1, 2, 3})
+
+	scanService := newTestScanner(t)
+	report, err := scanService.ScanDirectory(context.Background(), "https://example.test/package.zip", "archive-sha", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Schema != 1 || report.SHA256 != "archive-sha" || !report.Summary.Complete {
+		t.Fatalf("unexpected report header: %#v", report)
+	}
+	if report.Summary.FilesVisited != 6 || report.Summary.FilesScanned != 5 {
+		t.Fatalf("summary = %#v", report.Summary)
+	}
+	if !hasExpression(report.Summary.RootExpressions, "mit", licenses.Identified) {
+		t.Fatalf("root expressions = %#v", report.Summary.RootExpressions)
+	}
+	if !hasExpression(report.Summary.OtherExpressions, "apache-2.0", licenses.Identified) ||
+		!hasIdentification(report.Summary.OtherExpressions, licenses.Partial) ||
+		!hasIdentification(report.Summary.OtherExpressions, licenses.NoAssertion) {
+		t.Fatalf("other expressions = %#v", report.Summary.OtherExpressions)
+	}
+	if len(report.AttributionFiles) != 3 {
+		t.Fatalf("attribution files = %#v", report.AttributionFiles)
+	}
+	license := findAttribution(t, report, "LICENSE")
+	if license.Content != mitLicense || !slices.Equal(license.Roles, []string{"license"}) {
+		t.Fatalf("LICENSE attribution = %#v", license)
+	}
+	if file := findFile(t, report, "LICENSE"); file.LicenseTextCoverage <= 0 {
+		t.Fatalf("LICENSE coverage = %v", file.LicenseTextCoverage)
+	}
+	notice := findAttribution(t, report, "NOTICE")
+	if !slices.Equal(notice.Roles, []string{"notice"}) {
+		t.Fatalf("NOTICE roles = %#v", notice.Roles)
+	}
+	if len(report.Skipped) != 1 || report.Skipped[0].Reason != "binary" {
+		t.Fatalf("skipped = %#v", report.Skipped)
+	}
+	if len(report.Errors) != 0 {
+		t.Fatalf("errors = %#v", report.Errors)
+	}
+}
+
+func TestScanDirectoryNoDetectionsWithWarningsIsComplete(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "plain.txt", []byte("There is no licensing statement here."))
+	writeTestFile(t, root, "binary", []byte{0, 1})
+	scanService := newTestScanner(t)
+	report, err := scanService.ScanDirectory(context.Background(), "https://example.test/empty.zip", "sha", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Summary.Complete || len(report.Files) != 0 || len(report.Errors) != 0 {
+		t.Fatalf("report = %#v", report)
+	}
+	if len(report.Skipped) != 1 || report.Skipped[0].Reason != "binary" {
+		t.Fatalf("skipped = %#v", report.Skipped)
+	}
+}
+
+func TestScanDirectoryTwoRootLicenseTexts(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "LICENSE", []byte(mitLicense))
+	writeTestFile(t, root, "COPYING", []byte("SPDX-License-Identifier: Apache-2.0\n"))
+	report, err := newTestScanner(t).ScanDirectory(
+		context.Background(), "https://example.test/two.zip", "sha", root,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasExpression(report.Summary.RootExpressions, "mit", licenses.Identified) ||
+		!hasExpression(report.Summary.RootExpressions, "apache-2.0", licenses.Identified) {
+		t.Fatalf("root expressions = %#v", report.Summary.RootExpressions)
+	}
+}
+
+func TestScanDirectoryEncodedSPDXOffsets(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		encoding string
+		needle   []byte
+	}{
+		{
+			name: "utf8-bom", data: append([]byte{0xef, 0xbb, 0xbf}, []byte("// SPDX-License-Identifier: MIT\n")...),
+			encoding: "utf-8", needle: []byte("SPDX-License-Identifier: MIT"),
+		},
+		{
+			name: "utf16le", data: encodeUTF16([]rune("// SPDX-License-Identifier: MIT\n"), binary.LittleEndian),
+			encoding: "utf-16le", needle: encodeUTF16([]rune("SPDX-License-Identifier: MIT"), binary.LittleEndian)[2:],
+		},
+		{
+			name: "utf16be", data: encodeUTF16([]rune("// SPDX-License-Identifier: MIT\n"), binary.BigEndian),
+			encoding: "utf-16be", needle: encodeUTF16([]rune("SPDX-License-Identifier: MIT"), binary.BigEndian)[2:],
+		},
+		{
+			name: "latin1", data: append([]byte{'/', '/', ' ', 'c', 'a', 'f', 0xe9, '\n'}, []byte("// SPDX-License-Identifier: MIT\n")...),
+			encoding: "iso-8859-1", needle: []byte("SPDX-License-Identifier: MIT"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeTestFile(t, root, test.name+".txt", test.data)
+			report, err := newTestScanner(t).ScanDirectory(
+				context.Background(), "https://example.test/encoded.zip", "sha", root,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			file := findFile(t, report, test.name+".txt")
+			match := findMethodMatch(t, file, licenses.SpdxID)
+			start := bytes.Index(test.data, test.needle)
+			if file.Encoding != test.encoding || match.Start != start || match.End != start+len(test.needle) {
+				t.Fatalf("encoding=%q range=[%d,%d), want %q [%d,%d)", file.Encoding, match.Start, match.End, test.encoding, start, start+len(test.needle))
+			}
+		})
+	}
+}
+
+func TestScanDirectoryStableUnderConcurrency(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "LICENSE", []byte(mitLicense))
+	writeTestFile(t, root, "src/main.go", []byte("// SPDX-License-Identifier: MIT\n"))
+	scanService := newTestScanner(t)
+	const count = 4
+	results := make(chan []byte, count)
+	errors := make(chan error, count)
+	var workers sync.WaitGroup
+	for range count {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			report, err := scanService.ScanDirectory(context.Background(), "https://example.test/stable.zip", "sha", root)
+			if err != nil {
+				errors <- err
+				return
+			}
+			encoded, err := json.Marshal(report)
+			if err != nil {
+				errors <- err
+				return
+			}
+			results <- encoded
+		}()
+	}
+	workers.Wait()
+	close(results)
+	close(errors)
+	for err := range errors {
+		t.Fatal(err)
+	}
+	var first []byte
+	for result := range results {
+		if first == nil {
+			first = result
+			continue
+		}
+		if !bytes.Equal(first, result) {
+			t.Fatalf("non-deterministic JSON:\n%s\n%s", first, result)
+		}
+	}
+}
+
+func TestScanURLExistingFixtures(t *testing.T) {
+	fixtureRoot := filepath.Join("..", "..", "test", "fixtures", "files")
+	server := httptest.NewServer(http.FileServer(http.Dir(fixtureRoot)))
+	defer server.Close()
+	scanService := newTestScanner(t)
+	scanService.ArchiveClient = &archivepkg.Client{
+		HTTPClient: server.Client(), Limits: archivepkg.DefaultDownloadLimits(), AllowPrivateHosts: true,
+	}
+	fixtures := map[string]string{
+		"main.zip":                   "agpl-3.0",
+		"pkg-1.0.0.tgz":              "mit",
+		"clj-data-adapter-0.2.1.jar": "",
+	}
+	for fixture, legacyExpression := range fixtures {
+		t.Run(fixture, func(t *testing.T) {
+			report, err := scanService.ScanURL(context.Background(), server.URL+"/"+fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if report.SHA256 == "" || report.Summary.FilesVisited == 0 {
+				t.Fatalf("report = %#v", report)
+			}
+			if legacyExpression != "" && !hasExpression(report.Summary.RootExpressions, legacyExpression, licenses.Identified) {
+				t.Fatalf("v1 detected %q; v2 root expressions = %#v", legacyExpression, report.Summary.RootExpressions)
+			}
+			if legacyExpression == "" && len(report.Summary.RootExpressions) != 0 {
+				t.Fatalf("v1 had no detection; v2 root expressions = %#v", report.Summary.RootExpressions)
+			}
+		})
+	}
+}
+
+func TestScanURLFixtureArchive(t *testing.T) {
+	data := makeScannerZIP(t, map[string][]byte{
+		"wrapper/LICENSE": []byte(mitLicense),
+		"wrapper/NOTICE":  []byte("notice"),
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(data)
+	}))
+	defer server.Close()
+	scanService := newTestScanner(t)
+	scanService.ArchiveClient = &archivepkg.Client{
+		HTTPClient: server.Client(), Limits: archivepkg.DefaultDownloadLimits(), AllowPrivateHosts: true,
+	}
+	report, err := scanService.ScanURL(context.Background(), server.URL+"/package.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasExpression(report.Summary.RootExpressions, "mit", licenses.Identified) {
+		t.Fatalf("root expressions = %#v", report.Summary.RootExpressions)
+	}
+	if findAttribution(t, report, "LICENSE").Content != mitLicense {
+		t.Fatal("complete LICENSE content was not returned")
+	}
+}
+
+func TestTextOffsetRemapping(t *testing.T) {
+	t.Parallel()
+	utf8BOM := append([]byte{0xef, 0xbb, 0xbf}, []byte("MIT")...)
+	assertRemappedRange(t, utf8BOM, 0, 3, 3, 6, "utf-8")
+
+	utf16LE := encodeUTF16([]rune("MIT"), binary.LittleEndian)
+	assertRemappedRange(t, utf16LE, 0, 3, 2, 8, "utf-16le")
+	utf16BE := encodeUTF16([]rune("MIT"), binary.BigEndian)
+	assertRemappedRange(t, utf16BE, 0, 3, 2, 8, "utf-16be")
+
+	latin1 := []byte{'c', 'a', 'f', 0xe9}
+	assertRemappedRange(t, latin1, 3, 5, 3, 4, "iso-8859-1")
+}
+
+func TestDiscoveryLimitsAndPolicy(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeTestFile(t, root, "one.txt", []byte("one"))
+	writeTestFile(t, root, "two.txt", []byte("two"))
+	writeTestFile(t, root, ".git/config", []byte("ignored"))
+	writeTestFile(t, root, "vendor/LICENSE", []byte(mitLicense))
+	limits := DefaultLimits()
+	limits.MaxFiles = 1
+	summary := Summary{}
+	tasks, skipped, scanErrors, truncated, err := discoverFiles(context.Background(), root, limits, &summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 || !truncated || len(skipped) < 2 {
+		t.Fatalf("tasks=%#v skipped=%#v truncated=%v", tasks, skipped, truncated)
+	}
+	if len(scanErrors) != 0 {
+		t.Fatalf("scan errors = %#v", scanErrors)
+	}
+}
+
+func TestLicenseTextCoverageMergesOverlappingRanges(t *testing.T) {
+	t.Parallel()
+	result := licenses.Result{Detections: []licenses.Detection{{Matches: []licenses.Match{
+		{Kind: licenses.KindText, Start: 0, End: 5},
+		{Kind: licenses.KindNotice, Start: 3, End: 8},
+		{Kind: licenses.KindReference, Start: 8, End: 10},
+	}}}}
+	if got := licenseTextCoverage(result, 10); got != 80 {
+		t.Fatalf("coverage = %v, want 80", got)
+	}
+}
+
+func TestAttributionLimitListsOmittedFiles(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "LICENSE", []byte(mitLicense))
+	writeTestFile(t, root, "NOTICE", []byte("notice"))
+	scanService := newTestScanner(t)
+	scanService.Limits.MaxAttributionFiles = 1
+	report, err := scanService.ScanDirectory(context.Background(), "https://example.test/package.zip", "sha", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.AttributionFiles) != 1 || !slices.ContainsFunc(report.Skipped, func(skip Skip) bool {
+		return skip.Path == "NOTICE" && skip.Reason == "attribution-limit"
+	}) {
+		t.Fatalf("attribution=%#v skipped=%#v", report.AttributionFiles, report.Skipped)
+	}
+}
+
+func newTestScanner(t *testing.T) *Scanner {
+	t.Helper()
+	scanService, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return scanService
+}
+
+func writeTestFile(t *testing.T, root, name string, data []byte) {
+	t.Helper()
+	filePath := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func hasExpression(expressions []Expression, expression string, identification licenses.Identification) bool {
+	return slices.ContainsFunc(expressions, func(candidate Expression) bool {
+		return candidate.Expression == expression && candidate.Identification == identification
+	})
+}
+
+func hasIdentification(expressions []Expression, identification licenses.Identification) bool {
+	return slices.ContainsFunc(expressions, func(candidate Expression) bool {
+		return candidate.Identification == identification
+	})
+}
+
+func findAttribution(t *testing.T, report Report, name string) AttributionFile {
+	t.Helper()
+	for _, file := range report.AttributionFiles {
+		if file.Path == name {
+			return file
+		}
+	}
+	t.Fatalf("attribution file %q not found in %#v", name, report.AttributionFiles)
+	return AttributionFile{}
+}
+
+func findFile(t *testing.T, report Report, name string) File {
+	t.Helper()
+	for _, file := range report.Files {
+		if file.Path == name {
+			return file
+		}
+	}
+	t.Fatalf("file %q not found in %#v", name, report.Files)
+	return File{}
+}
+
+func findMethodMatch(t *testing.T, file File, method licenses.Method) Match {
+	t.Helper()
+	for _, detection := range file.Detections {
+		for _, match := range detection.Matches {
+			if match.Method == method {
+				return match
+			}
+		}
+	}
+	t.Fatalf("method %q not found in %#v", method, file)
+	return Match{}
+}
+
+func assertRemappedRange(
+	t *testing.T,
+	raw []byte,
+	decodedStart, decodedEnd, rawStart, rawEnd int,
+	encoding string,
+) {
+	t.Helper()
+	decoded := decodeText(raw)
+	result := licenses.Result{Detections: []licenses.Detection{{
+		Matches: []licenses.Match{{Start: decodedStart, End: decodedEnd}},
+	}}}
+	remapResultOffsets(&result, decoded)
+	match := result.Detections[0].Matches[0]
+	if decoded.encoding != encoding || match.Start != rawStart || match.End != rawEnd {
+		t.Fatalf("encoding=%q range=[%d,%d), want %q [%d,%d)", decoded.encoding, match.Start, match.End, encoding, rawStart, rawEnd)
+	}
+}
+
+func encodeUTF16(input []rune, order binary.ByteOrder) []byte {
+	words := utf16.Encode(input)
+	result := make([]byte, 2+len(words)*2)
+	if order == binary.LittleEndian {
+		result[0], result[1] = 0xff, 0xfe
+	} else {
+		result[0], result[1] = 0xfe, 0xff
+	}
+	for index, word := range words {
+		order.PutUint16(result[2+index*2:], word)
+	}
+	return result
+}
+
+func makeScannerZIP(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	for name, data := range files {
+		member, err := writer.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := member.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func BenchmarkScanDirectory(b *testing.B) {
+	root := b.TempDir()
+	filePath := filepath.Join(root, "LICENSE")
+	if err := os.WriteFile(filePath, []byte(mitLicense), 0o600); err != nil {
+		b.Fatal(err)
+	}
+	scanService, err := New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := scanService.ScanDirectory(context.Background(), "benchmark", "sha", root); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -16,6 +16,7 @@ import (
 	"unicode/utf16"
 
 	licenses "github.com/git-pkgs/licenses"
+	"github.com/git-pkgs/magic"
 
 	archivepkg "github.com/ecosyste-ms/licenses/internal/archive"
 )
@@ -410,7 +411,7 @@ func assertRemappedRange(
 	encoding string,
 ) {
 	t.Helper()
-	decoded := decodeText(raw)
+	decoded := decodeText(raw, magic.Detect(raw))
 	result := licenses.Result{Detections: []licenses.Detection{{
 		Matches: []licenses.Match{{Start: decodedStart, End: decodedEnd}},
 	}}}

--- a/internal/scanner/text.go
+++ b/internal/scanner/text.go
@@ -7,12 +7,10 @@ import (
 	"unicode/utf8"
 
 	licenses "github.com/git-pkgs/licenses"
+	"github.com/git-pkgs/magic"
 )
 
-const (
-	binaryProbeSize = 8 << 10
-	utf8BOMSize     = 3
-)
+const utf8BOMSize = 3
 
 type decodedText struct {
 	data       []byte
@@ -21,27 +19,24 @@ type decodedText struct {
 	encoding   string
 }
 
-func isBinary(data []byte) bool {
-	probe := data[:min(len(data), binaryProbeSize)]
-	if bytes.HasPrefix(probe, []byte{0xff, 0xfe}) || bytes.HasPrefix(probe, []byte{0xfe, 0xff}) {
-		return false
-	}
-	return bytes.IndexByte(probe, 0) >= 0
-}
-
-func decodeText(data []byte) decodedText {
-	switch {
-	case bytes.HasPrefix(data, []byte{0xef, 0xbb, 0xbf}):
-		return decodedText{data: data[utf8BOMSize:], offsetBase: utf8BOMSize, encoding: "utf-8"}
-	case bytes.HasPrefix(data, []byte{0xff, 0xfe}):
-		return decodeUTF16(data, binary.LittleEndian, "utf-16le")
-	case bytes.HasPrefix(data, []byte{0xfe, 0xff}):
-		return decodeUTF16(data, binary.BigEndian, "utf-16be")
-	case utf8.Valid(data):
+func decodeText(data []byte, detection magic.Result) decodedText {
+	switch detection.Encoding {
+	case "utf-8":
+		if bytes.HasPrefix(data, []byte{0xef, 0xbb, 0xbf}) {
+			return decodedText{
+				data: data[utf8BOMSize:], offsetBase: utf8BOMSize, encoding: "utf-8",
+			}
+		}
 		return decodedText{data: data, encoding: "utf-8"}
-	default:
+	case "utf-16le":
+		return decodeUTF16(data, binary.LittleEndian, "utf-16le")
+	case "utf-16be":
+		return decodeUTF16(data, binary.BigEndian, "utf-16be")
+	}
+	if detection.Kind == magic.KindUnknown && detection.Reason == magic.ReasonInvalidText {
 		return decodeLatin1(data)
 	}
+	return decodedText{data: data, encoding: "utf-8"}
 }
 
 func decodeUTF16(data []byte, order binary.ByteOrder, encoding string) decodedText {

--- a/internal/scanner/text.go
+++ b/internal/scanner/text.go
@@ -1,0 +1,121 @@
+package scanner
+
+import (
+	"bytes"
+	"encoding/binary"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	licenses "github.com/git-pkgs/licenses"
+)
+
+const (
+	binaryProbeSize = 8 << 10
+	utf8BOMSize     = 3
+)
+
+type decodedText struct {
+	data       []byte
+	offsets    []int
+	offsetBase int
+	encoding   string
+}
+
+func isBinary(data []byte) bool {
+	probe := data[:min(len(data), binaryProbeSize)]
+	if bytes.HasPrefix(probe, []byte{0xff, 0xfe}) || bytes.HasPrefix(probe, []byte{0xfe, 0xff}) {
+		return false
+	}
+	return bytes.IndexByte(probe, 0) >= 0
+}
+
+func decodeText(data []byte) decodedText {
+	switch {
+	case bytes.HasPrefix(data, []byte{0xef, 0xbb, 0xbf}):
+		return decodedText{data: data[utf8BOMSize:], offsetBase: utf8BOMSize, encoding: "utf-8"}
+	case bytes.HasPrefix(data, []byte{0xff, 0xfe}):
+		return decodeUTF16(data, binary.LittleEndian, "utf-16le")
+	case bytes.HasPrefix(data, []byte{0xfe, 0xff}):
+		return decodeUTF16(data, binary.BigEndian, "utf-16be")
+	case utf8.Valid(data):
+		return decodedText{data: data, encoding: "utf-8"}
+	default:
+		return decodeLatin1(data)
+	}
+}
+
+func decodeUTF16(data []byte, order binary.ByteOrder, encoding string) decodedText {
+	decoded := decodedText{data: make([]byte, 0, len(data)), offsets: []int{2}, encoding: encoding}
+	for position := 2; position < len(data); {
+		start := position
+		var character rune
+		if position+1 >= len(data) {
+			character = utf8.RuneError
+			position++
+		} else {
+			first := order.Uint16(data[position : position+2])
+			position += 2
+			character = rune(first)
+			if utf16.IsSurrogate(character) {
+				if position+1 < len(data) {
+					second := rune(order.Uint16(data[position : position+2]))
+					if decodedRune := utf16.DecodeRune(character, second); decodedRune != utf8.RuneError {
+						character = decodedRune
+						position += 2
+					} else {
+						character = utf8.RuneError
+					}
+				} else {
+					character = utf8.RuneError
+				}
+			}
+		}
+		decoded.appendRune(character, start, position)
+	}
+	return decoded
+}
+
+func decodeLatin1(data []byte) decodedText {
+	decoded := decodedText{data: make([]byte, 0, len(data)), offsets: []int{0}, encoding: "iso-8859-1"}
+	for position, value := range data {
+		decoded.appendRune(rune(value), position, position+1)
+	}
+	return decoded
+}
+
+func (decoded *decodedText) appendRune(character rune, rawStart, rawEnd int) {
+	start := len(decoded.data)
+	decoded.data = utf8.AppendRune(decoded.data, character)
+	for position := start; position < len(decoded.data); position++ {
+		if position == len(decoded.data)-1 {
+			decoded.offsets = append(decoded.offsets, rawEnd)
+		} else {
+			decoded.offsets = append(decoded.offsets, rawStart)
+		}
+	}
+}
+
+func (decoded decodedText) rawOffset(offset int) int {
+	if decoded.offsets != nil {
+		return decoded.offsets[offset]
+	}
+	return offset + decoded.offsetBase
+}
+
+func remapResultOffsets(result *licenses.Result, decoded decodedText) {
+	if decoded.offsets == nil && decoded.offsetBase == 0 {
+		return
+	}
+	for detectionIndex := range result.Detections {
+		for matchIndex := range result.Detections[detectionIndex].Matches {
+			match := &result.Detections[detectionIndex].Matches[matchIndex]
+			match.Start = decoded.rawOffset(match.Start)
+			match.End = decoded.rawOffset(match.End)
+		}
+	}
+	for matchIndex := range result.Clues {
+		match := &result.Clues[matchIndex]
+		match.Start = decoded.rawOffset(match.Start)
+		match.End = decoded.rawOffset(match.End)
+	}
+}

--- a/openapi/api/v2/openapi.yaml
+++ b/openapi/api/v2/openapi.yaml
@@ -1,0 +1,359 @@
+openapi: 3.0.3
+info:
+  title: "Ecosyste.ms: Licenses v2"
+  description: >-
+    Synchronously downloads a bounded package archive and returns deterministic
+    license detections, clues, attribution files, skipped paths, and scan errors.
+    Schema 1 is additive; clients must ignore fields they do not recognize.
+  version: 2.0.0
+  contact:
+    name: Ecosyste.ms
+    email: support@ecosyste.ms
+    url: https://ecosyste.ms
+  license:
+    name: CC-BY-SA-4.0
+    url: https://creativecommons.org/licenses/by-sa/4.0/
+externalDocs:
+  description: Source repository
+  url: https://github.com/ecosyste-ms/licenses
+servers:
+  - url: https://licenses.ecosyste.ms
+paths:
+  /api/v2/licenses:
+    get:
+      summary: Scan a remote package archive for license evidence
+      operationId: scanLicensesV2
+      parameters:
+        - name: url
+          in: query
+          required: true
+          description: Public HTTP or HTTPS URL of a supported package archive.
+          schema:
+            type: string
+            format: uri
+      responses:
+        "200":
+          description: The archive was downloaded and scanned.
+          headers:
+            Cache-Control:
+              description: Shared-cache policy for the completed response.
+              schema:
+                type: string
+            ETag:
+              description: Strong validator containing the archive SHA-256.
+              schema:
+                type: string
+            X-Archive-SHA256:
+              description: SHA-256 of the compressed archive bytes.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScanReport"
+        "400":
+          description: The request URL or archive format is invalid or unsupported.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: A configured download, archive entry, depth, or expanded-byte limit was exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: An unexpected extraction or matching failure occurred.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "502":
+          description: The remote archive could not be downloaded successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: The bounded scan timed out.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    ScanReport:
+      type: object
+      additionalProperties: true
+      required:
+        - schema
+        - url
+        - sha256
+        - scanner
+        - summary
+        - declared
+        - files
+        - attribution_files
+        - skipped
+        - errors
+      properties:
+        schema:
+          type: integer
+          enum: [1]
+        url:
+          type: string
+          format: uri
+        sha256:
+          $ref: "#/components/schemas/SHA256"
+        scanner:
+          $ref: "#/components/schemas/Scanner"
+        summary:
+          $ref: "#/components/schemas/Summary"
+        declared:
+          type: array
+          items:
+            $ref: "#/components/schemas/DeclaredLicense"
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/File"
+        attribution_files:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttributionFile"
+        skipped:
+          type: array
+          items:
+            $ref: "#/components/schemas/SkippedPath"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ScanError"
+    Scanner:
+      type: object
+      additionalProperties: true
+      required: [name, version, corpus]
+      properties:
+        name:
+          type: string
+          enum: [git-pkgs/licenses]
+        version:
+          type: string
+          example: 0.2.0
+        corpus:
+          $ref: "#/components/schemas/Corpus"
+    Corpus:
+      type: object
+      additionalProperties: true
+      required: [version, source_commit, rule_count]
+      properties:
+        version:
+          type: string
+        source_commit:
+          type: string
+          pattern: "^[0-9a-f]{40}$"
+        rule_count:
+          type: integer
+          minimum: 1
+    Summary:
+      type: object
+      additionalProperties: true
+      required:
+        - complete
+        - files_visited
+        - files_scanned
+        - bytes_scanned
+        - root_expressions
+        - other_expressions
+      properties:
+        complete:
+          type: boolean
+          description: False when file discovery was truncated or one or more files failed to scan.
+        files_visited:
+          type: integer
+          minimum: 0
+        files_scanned:
+          type: integer
+          minimum: 0
+        bytes_scanned:
+          type: integer
+          format: int64
+          minimum: 0
+        root_expressions:
+          type: array
+          description: Evidence from legal or README files at the archive root after common-wrapper removal.
+          items:
+            $ref: "#/components/schemas/Expression"
+        other_expressions:
+          type: array
+          description: Evidence from nested and ordinary files; it is not a claimed project license.
+          items:
+            $ref: "#/components/schemas/Expression"
+    Expression:
+      type: object
+      additionalProperties: true
+      required: [expression, identification]
+      properties:
+        expression:
+          type: string
+          description: ScanCode expression copied exactly from the matched rule.
+        identification:
+          $ref: "#/components/schemas/Identification"
+    Identification:
+      type: string
+      enum: [identified, partial, NOASSERTION]
+    DeclaredLicense:
+      type: object
+      additionalProperties: true
+      required: [path, raw]
+      properties:
+        path:
+          type: string
+        raw:
+          type: string
+        normalized_expression:
+          type: string
+    File:
+      type: object
+      additionalProperties: true
+      required:
+        - path
+        - size
+        - sha256
+        - encoding
+        - license_text_coverage
+        - detections
+        - clues
+      properties:
+        path:
+          type: string
+        size:
+          type: integer
+          format: int64
+          minimum: 0
+        sha256:
+          $ref: "#/components/schemas/SHA256"
+        encoding:
+          type: string
+          enum: [utf-8, utf-16le, utf-16be, iso-8859-1]
+        license_text_coverage:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 100
+        detections:
+          type: array
+          items:
+            $ref: "#/components/schemas/Detection"
+        clues:
+          type: array
+          items:
+            $ref: "#/components/schemas/Match"
+    Detection:
+      type: object
+      additionalProperties: true
+      required: [expression, identification, matches]
+      properties:
+        expression:
+          type: string
+        identification:
+          $ref: "#/components/schemas/Identification"
+        matches:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/Match"
+    Match:
+      type: object
+      additionalProperties: true
+      required:
+        - rule_id
+        - license_ids
+        - kind
+        - method
+        - score
+        - coverage
+        - start
+        - end
+      properties:
+        rule_id:
+          type: string
+        license_ids:
+          type: array
+          items:
+            type: string
+        kind:
+          type: string
+          enum: [unknown, text, notice, tag, reference, intro, clue]
+        method:
+          type: string
+          enum: [hash, exact, spdx-id]
+        score:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 100
+        coverage:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 100
+        start:
+          type: integer
+          minimum: 0
+          description: Inclusive byte offset in the original archive entry.
+        end:
+          type: integer
+          minimum: 0
+          description: Exclusive byte offset in the original archive entry.
+    AttributionFile:
+      type: object
+      additionalProperties: true
+      required: [path, roles, sha256, encoding, content]
+      properties:
+        path:
+          type: string
+        roles:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+            enum: [license, notice]
+        sha256:
+          $ref: "#/components/schemas/SHA256"
+        encoding:
+          type: string
+          enum: [utf-8, utf-16le, utf-16be, iso-8859-1]
+        content:
+          type: string
+          description: Complete decoded file content; match offsets continue to address the original bytes.
+    SkippedPath:
+      type: object
+      additionalProperties: true
+      required: [path, reason]
+      properties:
+        path:
+          type: string
+        reason:
+          type: string
+    ScanError:
+      type: object
+      additionalProperties: true
+      required: [path, error]
+      properties:
+        path:
+          type: string
+        error:
+          type: string
+    SHA256:
+      type: string
+      pattern: "^[0-9a-f]{64}$"
+    Error:
+      type: object
+      additionalProperties: false
+      required: [error]
+      properties:
+        error:
+          type: string

--- a/test/integration/openapi_test.rb
+++ b/test/integration/openapi_test.rb
@@ -1,8 +1,12 @@
 require "test_helper"
 
 class OpenapiTest < ActiveSupport::TestCase
-  test 'openapi.yaml is valid' do
-    f = YAML.load_file(Rails.root.join('openapi/api/v1/openapi.yaml'))
-    assert_equal f.class, Hash
+  test 'OpenAPI documents are valid YAML mappings' do
+    Dir[Rails.root.join('openapi/api/*/openapi.yaml')].sort.each do |path|
+      document = YAML.safe_load_file(path, aliases: true)
+      assert_instance_of Hash, document, path
+      assert document.key?('openapi'), path
+      assert document.key?('paths'), path
+    end
   end
 end


### PR DESCRIPTION
Refs #1003

## Summary

Implements the first stage of #1003 by introducing an independent Go v2 license-scanning API backed by [`git-pkgs/licenses`](https://github.com/git-pkgs/licenses).

The existing Rails v1 service remains available and unchanged while the Go implementation can be built, tested and deployed independently.

## What changed

- Added `GET /api/v2/licenses?url=<archive-url>`
- Added structured license results containing:
  - SPDX expressions
  - file paths, roles, hashes and encodings
  - raw-byte offsets for matched evidence
  - attribution and coverage information
  - scan completeness, warnings and errors
- Initialized and shared the license matcher once per server process
- Added deterministic result ordering
- Added UTF-8, UTF-16, BOM and Latin-1 text handling
- Added Markdown weak-reference demotion
- Added support for:
  - ZIP and JAR archives
  - tar archives
  - tar.gz archives
  - tar.xz archives
  - Ruby gems
- Added archive safety protections:
  - SSRF and private-address rejection
  - redirect validation
  - download and extraction limits
  - path-traversal protection
  - symlink and special-entry rejection
  - request timeouts and concurrency limits
- Added archive hashing, ETag and cache headers
- Added the v2 OpenAPI specification
- Added an independent multi-stage Go Docker image
- Added Go checks to CI
- Added unit, integration, handler, archive and benchmark coverage

## Compatibility

This is an additive change:

- The Rails v1 API remains intact.
- Existing Rails clients are unaffected.
- The Go v2 server uses a separate entry point and Dockerfile.
- Client migration and Rails removal remain separate follow-up stages.

## Verification

The implementation was checked with:

- `gofmt`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- Existing Rails test suite
- Rails and Go Docker image builds
- Go v2 API smoke testing
